### PR TITLE
fix: stop tracking Android .cxx build files

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -63,6 +63,7 @@ pubspec.lock
 # Android related
 **/android/**/gradle-wrapper.jar
 .gradle/
+**/app/.cxx
 **/android/captures/
 **/android/gradlew
 **/android/gradlew.bat


### PR DESCRIPTION
Removes `.cxx` build files from version control and updates `.gitignore` to prevent them from being tracked in the future. These files are generated during the Android NDK build process and should not be included in the repository.