### PR TITLE
feat: add configurable participant name support with UI and docs

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,7 +34,7 @@ class _DataEntryState extends State<DataEntryScreen> {
   var licenseKey = "";
   var meetingUID = "";
   var isHost = false;
-  DaakiaMeetingConfiguration? _customConfig;
+  DaakiaMeetingConfiguration? customConfig;
 
   @override
   Widget build(BuildContext context) {
@@ -120,7 +120,7 @@ class _DataEntryState extends State<DataEntryScreen> {
                               );
                               if (result != null) {
                                 setState(() {
-                                  _customConfig = result;
+                                  customConfig = result;
                                 });
                               }
                             },
@@ -159,7 +159,7 @@ class _DataEntryState extends State<DataEntryScreen> {
                     meetingId: meetingUID,
                     secretKey: licenseKey,
                     isHost: isHost,
-                    configuration: _customConfig,
+                    configuration: customConfig,
                   ),
                 ),
               );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -54,6 +54,9 @@ class _DataEntryState extends State<DataEntryScreen> {
             borderSide: BorderSide(color: ThemeColor.primaryThemeColor),
           ),
         ),
+        textTheme: const TextTheme(
+          bodyMedium: TextStyle(color: Colors.white),
+        ),
       ),
       child: Scaffold(
         body: SafeArea(

--- a/example/lib/screen/configuration_screen.dart
+++ b/example/lib/screen/configuration_screen.dart
@@ -1,4 +1,5 @@
 import 'package:daakia_vc_flutter_sdk/model/daakia_meeting_configuration.dart';
+import 'package:daakia_vc_flutter_sdk/model/participant_config.dart';
 import 'package:example/utils/theme_color.dart';
 import 'package:flutter/material.dart';
 
@@ -13,6 +14,10 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
   bool _includeMetadata = false;
   final List<MapEntry<TextEditingController, TextEditingController>>
       _metadataControllers = [];
+
+  bool _customizeConfigName = false;
+  bool _isNameEditable = true;
+  final TextEditingController _configNameController = TextEditingController();
 
   void _addMetadataField() {
     if (_metadataControllers.isNotEmpty) {
@@ -57,11 +62,20 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
 
     return DaakiaMeetingConfiguration(
       metadata: metadata,
+      participantNameConfig: ParticipantNameConfig(
+        name: _customizeConfigName ? _configNameController.text.trim() : null,
+        isEditable: _customizeConfigName
+            ? (_configNameController.text.trim().isEmpty
+                ? true
+                : _isNameEditable)
+            : true,
+      ),
     );
   }
 
   @override
   void dispose() {
+    _configNameController.dispose();
     for (var entry in _metadataControllers) {
       entry.key.dispose();
       entry.value.dispose();
@@ -87,6 +101,9 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
             borderSide: BorderSide(color: ThemeColor.primaryThemeColor),
           ),
         ),
+        textTheme: const TextTheme(
+          bodyMedium: TextStyle(color: Colors.white),
+        ),
       ),
       child: Scaffold(
         appBar: AppBar(title: const Text("Custom Configuration")),
@@ -98,6 +115,38 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    SwitchListTile(
+                      title: const Text("Customize Config Name"),
+                      value: _customizeConfigName,
+                      onChanged: (value) {
+                        setState(() {
+                          _customizeConfigName = value;
+                          if (!value) {
+                            _configNameController.clear();
+                            _isNameEditable = false;
+                          }
+                        });
+                      },
+                    ),
+                    if (_customizeConfigName) ...[
+                      const SizedBox(height: 10),
+                      TextFormField(
+                        controller: _configNameController,
+                        decoration: const InputDecoration(
+                          labelText: "Participant Name",
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      SwitchListTile(
+                        title: const Text("Is Name Editable"),
+                        value: _isNameEditable,
+                        onChanged: (value) {
+                          setState(() {
+                            _isNameEditable = value;
+                          });
+                        },
+                      ),
+                    ],
                     SwitchListTile(
                       title: const Text("Include Metadata"),
                       value: _includeMetadata,

--- a/lib/daakia_vc_flutter_sdk.dart
+++ b/lib/daakia_vc_flutter_sdk.dart
@@ -10,6 +10,12 @@ import 'model/daakia_meeting_configuration.dart';
 import 'model/meeting_details_model.dart';
 
 class DaakiaVideoConferenceWidget extends StatefulWidget {
+  /// Creates a new instance of the [DaakiaVideoConferenceWidget].
+  ///
+  /// [secretKey] is the license key required for authenticating the meeting session.
+  /// [meetingId] is the unique identifier for the meeting.
+  /// [isHost] determines if the current participant is the meeting host.
+  /// [configuration] provides optional advanced customizations.
   const DaakiaVideoConferenceWidget(
       {required this.meetingId,
       required this.secretKey,
@@ -17,8 +23,18 @@ class DaakiaVideoConferenceWidget extends StatefulWidget {
       this.configuration,
       super.key});
 
+  /// Unique identifier for the meeting session.
   final String meetingId;
+
+  /// License key used to verify and authorize access to the meeting.
+  ///
+  /// This key is validated before allowing the user to join the session.
+  /// Make sure the provided key is valid for the associated [meetingId].
   final String secretKey;
+
+  /// Determines whether the user is a host.
+  ///
+  /// This can control special permissions in the meeting.
   final bool isHost;
 
   /// Optional advanced configuration for the meeting widget.

--- a/lib/model/daakia_meeting_configuration.dart
+++ b/lib/model/daakia_meeting_configuration.dart
@@ -1,3 +1,5 @@
+import 'package:daakia_vc_flutter_sdk/model/participant_config.dart';
+
 /// Configuration options for initializing the Daakia meeting.
 class DaakiaMeetingConfiguration {
   /// [BETA] Metadata to provide additional information about the participant.
@@ -11,9 +13,36 @@ class DaakiaMeetingConfiguration {
   /// This field is experimental and may change in future versions.
   final Map<String, dynamic>? metadata;
 
-  // Future config options can go here:
+  /// Optional configuration for participant name behavior.
+  ///
+  /// If `name` is provided inside [ParticipantNameConfig] and is non-empty,
+  /// then the `isEditable` flag controls whether the user can modify it in the pre-join screen.
+  ///
+  /// If `name` is not provided or is empty, the name field will always be editable.
+  final ParticipantNameConfig? participantNameConfig;
 
+  /// Defines configuration settings for initializing and customizing
+  /// a Daakia meeting session.
+  ///
+  /// Use this class to pass optional metadata and UI behavior settings
+  /// when launching a meeting using the Daakia SDK. This allows developers
+  /// to customize aspects like participant information (e.g., name),
+  /// and enable advanced features like attendance tracking or analytics.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// DaakiaMeetingConfiguration(
+  ///   metadata: {'identifier': 'user123', 'email': 'user@example.com'},
+  ///   participantNameConfig: ParticipantNameConfig(
+  ///     name: 'John Doe',
+  ///     isEditable: false,
+  ///   ),
+  /// );
+  /// ```
+  ///
+  /// All fields are optional and can be left null to use default behavior.
   const DaakiaMeetingConfiguration({
     this.metadata,
+    this.participantNameConfig
   });
 }

--- a/lib/model/participant_config.dart
+++ b/lib/model/participant_config.dart
@@ -8,6 +8,10 @@ class ParticipantNameConfig {
   /// This value is only respected if [name] is not empty.
   final bool isEditable;
 
+  /// If `name` is provided inside [ParticipantNameConfig] and is non-empty,
+  /// then the `isEditable` flag controls whether the user can modify it in the pre-join screen.
+  ///
+  /// If `name` is not provided or is empty, the name field will always be editable.
   const ParticipantNameConfig({
     this.name,
     this.isEditable = true,

--- a/lib/model/participant_config.dart
+++ b/lib/model/participant_config.dart
@@ -1,0 +1,15 @@
+/// Configuration for the participant's display name.
+class ParticipantNameConfig {
+  /// The default name to show on the pre-join screen.
+  final String? name;
+
+  /// Whether the participant can edit the name.
+  ///
+  /// This value is only respected if [name] is not empty.
+  final bool isEditable;
+
+  const ParticipantNameConfig({
+    this.name,
+    this.isEditable = true,
+  });
+}

--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -65,6 +65,9 @@ class _PreJoinState extends State<PreJoinScreen> {
 
   var _isCoHostVerified = false;
 
+  late TextEditingController _nameController;
+  late bool _isNameEditable;
+
   //============== RTC ===============
   StreamSubscription? _subscription;
   List<MediaDevice> _audioInputs = [];
@@ -87,6 +90,11 @@ class _PreJoinState extends State<PreJoinScreen> {
     _subscription =
         Hardware.instance.onDeviceChange.stream.listen(_loadDevices);
     Hardware.instance.enumerateDevices().then(_loadDevices);
+    final initialName = widget.configuration?.participantNameConfig?.name ?? "";
+    _nameController = TextEditingController(text: initialName);
+
+    _isNameEditable = initialName.isEmpty ||
+        (widget.configuration?.participantNameConfig?.isEditable ?? false);
     // Schedule verifyCoHost after widget is built
     WidgetsBinding.instance.addPostFrameCallback((_) {
       verifyCoHost();
@@ -720,6 +728,7 @@ class _PreJoinState extends State<PreJoinScreen> {
                         horizontal: 20, vertical: 10),
                     // Equivalent to marginHorizontal="20dp" and marginTop="10dp"
                     child: TextFormField(
+                      controller: _nameController,
                       decoration: const InputDecoration(
                         labelText: 'Name*', // Equivalent to hint="Name*"
                         border: OutlineInputBorder(),
@@ -728,7 +737,7 @@ class _PreJoinState extends State<PreJoinScreen> {
                         color: Colors
                             .black, // Equivalent to textColor="@color/black"
                       ),
-                      enabled: true, // Equivalent to android:enabled="false"
+                      enabled: _isNameEditable, // Equivalent to android:enabled="false"
                       onChanged: (String? value) {
                         setState(() {
                           name = value ?? "";
@@ -885,6 +894,7 @@ class _PreJoinState extends State<PreJoinScreen> {
   void dispose() {
     _subscription?.cancel();
     _participantTimer?.cancel();
+    _nameController.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
### Summary

This PR introduces support for configuring the participant name field in the PreJoin page. It includes:

- A new `ParticipantNameConfig` in `DaakiaMeetingConfiguration` to optionally set a name and its editability.
- UI changes in the example app to reflect these options.
- Proper theming and style fixes for better visibility in dark mode.
- Documentation updates for:
  - `ParticipantNameConfig`
  - `DaakiaMeetingConfiguration`
  - `DaakiaVideoConferenceWidget`