### PR TITLE
feat: show reactions based on feature config

### DIFF
--- a/lib/model/features.dart
+++ b/lib/model/features.dart
@@ -179,4 +179,6 @@ class Features {
 
   bool isAllowMultipleCoHost() => configurations?.allowMultipleCohost == 1;
 
+  bool isReactionAllowed() => configurations?.enableReaction == 1;
+
 }

--- a/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
@@ -132,7 +132,8 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
               buildOption(context,
                   icon: Icons.emoji_emotions, // Replace with your reaction icon
                   text: 'Reaction',
-                  isVisible: true, onTap: () {
+                  isVisible: viewModel.meetingDetails.features!
+                      .isReactionAllowed(), onTap: () {
                 Navigator.pop(context);
                 showEmojiDialog(viewModel);
               }),

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -854,6 +854,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
 
   void showReaction(String? emoji, RtcViewmodel? viewModel,
       {String name = "You"}) {
+    if(viewModel?.meetingDetails.features!.isReactionAllowed() == false) {return;}
     switch (emoji) {
       case "heart":
         emojiAsset = AnimatedEmojis.redHeart;


### PR DESCRIPTION
### Summary
This PR introduces conditional rendering of the reaction feature based on the `isReactionAllowed` flag provided by the backend.