### PR TITLE
feat: restrict profile editing based on host/self permissions

### DIFF
--- a/lib/model/features.dart
+++ b/lib/model/features.dart
@@ -185,4 +185,8 @@ class Features {
 
   bool isPrivateChatAllowed() => configurations?.enablePrivateChat == 1;
 
+  bool isProfileEditByHostAllowed() => configurations?.allowProfileEditByHost == 1;
+
+  bool isProfileEditBySelfAllowed() => configurations?.allowProfileEditBySelf == 1;
+
 }

--- a/lib/presentation/widgets/participant_tile.dart
+++ b/lib/presentation/widgets/participant_tile.dart
@@ -1,7 +1,7 @@
 import 'package:daakia_vc_flutter_sdk/model/remote_activity_data.dart';
-import 'package:daakia_vc_flutter_sdk/resources/colors/color.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/dialog/pariticipant_dialog_controls.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/widgets/initials_circle.dart';
+import 'package:daakia_vc_flutter_sdk/resources/colors/color.dart';
 import 'package:daakia_vc_flutter_sdk/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:livekit_client/livekit_client.dart';
@@ -35,10 +35,7 @@ class ParticipantTile extends StatelessWidget {
           InitialsCircle(
               initials: Utils.getInitials(
                   isForLobby ? lobbyRequest?.displayName : participant?.name),
-              onEdit: (!isForLobby &&
-                      ((participant?.identity ==
-                              viewModel.room.localParticipant?.identity) ||
-                          (viewModel.isHost() || viewModel.isCoHost())))
+              onEdit: _canEditProfile(viewModel, participant, isForLobby)
                   ? () {
                       _showEditNameDialog(context, viewModel);
                     }
@@ -202,5 +199,23 @@ class ParticipantTile extends StatelessWidget {
             ],
           );
         });
+  }
+
+  bool _canEditProfile(
+      RtcViewmodel viewModel, Participant? participant, bool isForLobby) {
+    if (isForLobby) return false;
+
+    final localId = viewModel.room.localParticipant?.identity;
+    final isSelf = participant?.identity == localId;
+
+    final features = viewModel.meetingDetails.features;
+
+    if (isSelf) {
+      return features?.isProfileEditBySelfAllowed() == true;
+    } else if (viewModel.isHost() || viewModel.isCoHost()) {
+      return features?.isProfileEditByHostAllowed() == true;
+    }
+
+    return false;
   }
 }


### PR DESCRIPTION
### Summary
This PR updates the profile editing logic to respect feature-level restrictions. Previously, local participants could edit their own profiles, and hosts/co-hosts could edit any participant’s profile. Now, editing capabilities are gated by:

- `isProfileEditBySelfAllowed`: allows self-editing.
- `isProfileEditByHostAllowed`: allows hosts/co-hosts to edit others' profiles.