### PR TITLE
fix: minor listener fixes

### DIFF
--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -1264,6 +1264,7 @@ class RtcViewmodel extends ChangeNotifier {
 
   set participantListForConsent(List<ConsentParticipant> list) {
     _participantListForConsent = list;
+    notifyListeners();
   }
 
   void updateRecordingConsentStatus(bool status) {


### PR DESCRIPTION
This PR addresses a missing call to `notifyListeners()` inside the setter of `participantListForConsent`. Without this, the UI would not react to updates made through the setter, leading to potential inconsistencies.

### ✅ Changes
- Added `notifyListeners()` to the `participantListForConsent` setter to trigger UI updates when the list is modified.