### PR TITLE
fix: name validation issue in PreJoin screen

### DIFF
--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -91,6 +91,7 @@ class _PreJoinState extends State<PreJoinScreen> {
         Hardware.instance.onDeviceChange.stream.listen(_loadDevices);
     Hardware.instance.enumerateDevices().then(_loadDevices);
     final initialName = widget.configuration?.participantNameConfig?.name ?? "";
+    name = initialName;
     _nameController = TextEditingController(text: initialName);
 
     _isNameEditable = initialName.isEmpty ||


### PR DESCRIPTION
### Summary:
Resolved an issue where the name passed via SDK config appeared in the input field but wasn't recognized during validation, causing a _"Please enter name"_ warning.

### Fix:
- Name from config is now correctly detected during join flow validation.