### PR TITLE
Feat/translated transcript download

### DIFF
--- a/lib/presentation/dialog/transcript_download_choice_dialog.dart
+++ b/lib/presentation/dialog/transcript_download_choice_dialog.dart
@@ -1,0 +1,56 @@
+// transcript_download_choice_dialog.dart
+import 'package:flutter/material.dart';
+
+enum TranscriptDownloadChoice {
+  original,
+  translated,
+}
+
+class TranscriptDownloadChoiceDialog extends StatelessWidget {
+  const TranscriptDownloadChoiceDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      title: const Text("Download Transcription", style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),),
+      content: const Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            "Choose which version of the transcription you want to download.",
+            style: TextStyle(fontSize: 16),
+          ),
+          SizedBox(height: 10),
+        ],
+      ),
+      actionsAlignment: MainAxisAlignment.spaceBetween,
+      actions: [
+        ElevatedButton.icon(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.grey[200],
+            foregroundColor: Colors.black87,
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+          ),
+          icon: const Icon(Icons.text_snippet_outlined),
+          label: const Text("Original"),
+          onPressed: () =>
+              Navigator.pop(context, TranscriptDownloadChoice.original),
+        ),
+        ElevatedButton.icon(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.blue,
+            foregroundColor: Colors.white,
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+          ),
+          icon: const Icon(Icons.translate),
+          label: const Text("Translated"),
+          onPressed: () =>
+              Navigator.pop(context, TranscriptDownloadChoice.translated),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/pages/transcription_screen.dart
+++ b/lib/presentation/pages/transcription_screen.dart
@@ -143,8 +143,7 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> {
         backgroundColor: Colors.black,
         iconTheme: const IconThemeData(color: Colors.white),
         actions: [
-          if ((!widget.viewModel.isHost() && !widget.viewModel.isCoHost()) &&
-              widget.viewModel.meetingDetails.features!
+          if (widget.viewModel.meetingDetails.features!
                   .isVoiceTextTranslationAllowed())
             IconButton(
               icon: SvgPicture.asset(

--- a/lib/presentation/pages/transcription_screen.dart
+++ b/lib/presentation/pages/transcription_screen.dart
@@ -11,6 +11,7 @@ import '../../model/language_model.dart';
 import '../../utils/utils.dart';
 import '../../viewmodel/rtc_viewmodel.dart';
 import '../dialog/language_select_dialog.dart';
+import '../dialog/transcript_download_choice_dialog.dart';
 
 class TranscriptionScreen extends StatefulWidget {
   final RtcViewmodel viewModel;
@@ -85,19 +86,50 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> {
   }
 
   Future<void> handleDownloadButtonPressed() async {
-    setState(() {
-      _isLoading = true;
-    });
-    String formattedTranscript =
-        Utils.getTranscriptFormattedToSave(widget.viewModel.transcriptionList);
-    var result = await Utils.saveDataToFile(formattedTranscript,
-        "caption_${widget.viewModel.meetingDetails.meetingUid}_${DateTime.now().millisecondsSinceEpoch}");
+    String formattedTranscript;
+
+    final isTranslationAllowed = widget.viewModel.meetingDetails.features!
+        .isVoiceTextTranslationAllowed();
+
+    if (isTranslationAllowed) {
+      final choice = await showDialog<TranscriptDownloadChoice>(
+        context: context,
+        builder: (context) => const TranscriptDownloadChoiceDialog(),
+      );
+
+      if (choice == null) return;
+
+      setState(() {
+        _isLoading = true;
+      });
+
+      formattedTranscript = (choice == TranscriptDownloadChoice.translated)
+          ? Utils.getTranslatedTranscriptFormattedToSave(
+              widget.viewModel.transcriptionList)
+          : Utils.getTranscriptFormattedToSave(
+              widget.viewModel.transcriptionList);
+    } else {
+      setState(() {
+        _isLoading = true;
+      });
+      formattedTranscript = Utils.getTranscriptFormattedToSave(
+          widget.viewModel.transcriptionList);
+    }
+
+    final result = await Utils.saveDataToFile(
+      formattedTranscript,
+      "caption_${widget.viewModel.meetingDetails.meetingUid}_${DateTime.now().millisecondsSinceEpoch}",
+    );
+
     setState(() {
       _isLoading = false;
     });
 
     if (result.isSuccess) {
-      widget.viewModel.sendEvent(ShowTranscriptionDownload(message: "File saved successfully!", path: result.filePath));
+      widget.viewModel.sendEvent(ShowTranscriptionDownload(
+        message: "File saved successfully!",
+        path: result.filePath,
+      ));
     } else {
       widget.viewModel.sendMessageToUI("Failed to save file!");
     }
@@ -144,7 +176,7 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> {
         iconTheme: const IconThemeData(color: Colors.white),
         actions: [
           if (widget.viewModel.meetingDetails.features!
-                  .isVoiceTextTranslationAllowed())
+              .isVoiceTextTranslationAllowed())
             IconButton(
               icon: SvgPicture.asset(
                 'assets/icons/ic_translate_chats_colored.svg',

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -319,6 +319,24 @@ class Utils {
     return contentBuffer.toString();
   }
 
+  static String getTranslatedTranscriptFormattedToSave(
+      List<TranscriptionModel> transcriptions) {
+    StringBuffer contentBuffer = StringBuffer();
+    for (var entry in transcriptions) {
+      final String textToUse = (entry.translatedTranscription != null &&
+          entry.translatedTranscription!.trim().isNotEmpty)
+          ? (entry.translatedTranscription ?? "")
+          : entry.transcription;
+
+      contentBuffer.writeln('${entry.name} ${entry.timestamp}');
+      contentBuffer.writeln(textToUse);
+      contentBuffer.writeln();
+      contentBuffer.writeln();
+    }
+    return contentBuffer.toString();
+  }
+
+
   static Future<SavedData> saveDataToFile(String data, String fileName) async {
     try {
       // Request storage permission for Android only


### PR DESCRIPTION
## 📄 Description

This PR adds support for downloading meeting transcriptions with an option to choose between:

- Original captions
- Translated captions (if translation is enabled for the meeting)

A dialog is shown to the user if translation is allowed, otherwise the original transcript is downloaded directly.

## ✅ Changes

- Added `TranscriptDownloadChoiceDialog` for user selection
- Updated `handleDownloadButtonPressed` to support conditional logic
- Improved UX by showing loader only during the download process