### PR TITLE
Fix/co-host attendance issue

### DIFF
--- a/lib/presentation/pages/all_participant_page.dart
+++ b/lib/presentation/pages/all_participant_page.dart
@@ -55,7 +55,7 @@ class AllParticipantPage extends StatelessWidget {
                     children: [
                       LobbyRequestWidget(viewModel: viewModel),
                       JoinedParticipantWidget(viewModel: viewModel),
-                      if (viewModel.pendingParticipantList.isNotEmpty)
+                      if (viewModel.pendingParticipantList.isNotEmpty && (viewModel.isHost() || viewModel.isCoHost()))
                         PendingAttendanceWidget(viewModel: viewModel)
                     ],
                   ),

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -375,6 +375,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
           storageHelper
               .setAttendanceId(Utils.getMetadataAttendanceId(metadata));
           storageHelper.setHostToken(remoteData.token ?? "");
+          viewModel?.getAttendanceListForParticipant();
         } else {
           viewModel?.setCoHost(false);
           StorageHelper().clearAllData();


### PR DESCRIPTION
This PR resolves an issue where co-hosts were not appearing in the active participant list during the attendance flow.

### ✅ Changes Made:
- Added role check for `isCoHost()` in the active participant filter logic
- Ensured co-hosts are treated similarly to hosts in attendance-related views

### 🔍 Impact:
Co-hosts will now be correctly visible in the active participant section during attendance, improving accuracy and consistency.

---