### PR TITLE
fix: auto-start recording consent

### DIFF
--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -1329,6 +1329,9 @@ class RtcViewmodel extends ChangeNotifier {
               getParticipantConsentList();
             }
           } else {
+            if (asUser) {
+              return;
+            }
             startRecordingConsent();
           }
         },


### PR DESCRIPTION
### Description:
Fixed an issue where the recording consent dialog was being shown to newly joined users **even when recording consent had not been started**. This was causing confusion as users were prompted prematurely.

### Changes:
- Updated the logic to ensure the recording consent dialog only appears **after** the recording consent flow has been initiated.
- Added proper checks to prevent early triggering of the dialog for new participants.

---