### PR TITLE
Fix: Handle duplicate entries and re-request recording consent after recording restart

### DIFF
--- a/lib/model/consent_participant.dart
+++ b/lib/model/consent_participant.dart
@@ -46,9 +46,19 @@ class ConsentParticipant {
 
   static List<ConsentParticipant> fromRemoteList(
       List<RemoteParticipantConsent> remoteList) {
-    return remoteList
+    final Map<String, RemoteParticipantConsent> uidToParticipant = {};
+
+    for (var remote in remoteList) {
+      final uid = remote.rtcParticipantUid;
+      if (uid != null) {
+        // Always keep the latest one — this will overwrite any earlier entry
+        uidToParticipant[uid] = remote;
+      }
+    }
+
+    return uidToParticipant.values
         .map((remote) => ConsentParticipant.fromRemote(remote))
-        .toList();
+        .toList(); // final list will have latest entries at the end
   }
 
   factory ConsentParticipant.fromRemoteParticipant(RemoteParticipant remote) {

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -251,7 +251,9 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     ..on<RoomRecordingStatusChanged>((event) {
       var viewModel = _livekitProviderKey.currentState?.viewModel;
       viewModel?.setRecording(event.activeRecording);
-      // context.showRecordingStatusChangedDialog(event.activeRecording);
+      if(!event.activeRecording) {
+        clearConsentList(viewModel);
+      }
     })
     ..on<RoomAttemptReconnectEvent>((event) {
       if (kDebugMode) {
@@ -379,12 +381,14 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         } else {
           viewModel?.setCoHost(false);
           StorageHelper().clearAllData();
+          clearConsentList(viewModel);
         }
         break;
 
       case MeetingActions.removeCoHost:
         viewModel?.setCoHost(false);
         StorageHelper().clearAllData();
+        clearConsentList(viewModel);
         break;
 
       case MeetingActions.forceMuteAll:
@@ -1102,5 +1106,11 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     ).then((_) {
       _isConsentRejectedDialogOpen = false; // Reset when dialog is dismissed
     });
+  }
+
+  void clearConsentList(RtcViewmodel? viewModel) {
+    if (viewModel?.meetingDetails.features?.isRecordingConsentAllowed() == true){
+      viewModel?.participantListForConsent.clear();
+    }
   }
 }


### PR DESCRIPTION
## 📄 Description

This PR addresses two key issues related to the recording consent flow:

1. **Duplicate Consent Entries**
   - Fixed a bug where duplicate entries appeared in the consent list.
   - Ensured uniqueness when managing consent data.

2. **Consent Re-Request on Recording Restart**
   - Ensured the app prompts for recording consent again after a restart.
   - This aligns with our consent policy and improves user experience in sessions interrupted by restarts.

---