### PR TITLE
Improve Recording Consent Flow: Prevent Repeat Prompts & Enable Host/Co-Host Consent Without Popup

### DIFF
--- a/lib/model/consent_participant.dart
+++ b/lib/model/consent_participant.dart
@@ -70,4 +70,19 @@ class ConsentParticipant {
       consent: "pending",
     );
   }
+
+  ConsentParticipant copyWith({
+    String? participantId,
+    String? participantName,
+    String? participantAvatar,
+    String? consent,
+  }) {
+    return ConsentParticipant(
+      participantId: participantId ?? this.participantId,
+      participantName: participantName ?? this.participantName,
+      participantAvatar: participantAvatar ?? this.participantAvatar,
+      consent: consent ?? this.consent,
+    );
+  }
+
 }

--- a/lib/presentation/widgets/recording_consent_tile.dart
+++ b/lib/presentation/widgets/recording_consent_tile.dart
@@ -64,10 +64,23 @@ class RecordingConsentTile extends StatelessWidget {
           if (consentStatus.shouldShowResend)
             IconButton(
               onPressed: () {
-                viewModel.resendRecordingConsent(participant.participantId);
+                if (participant.participantId == viewModel.participant.identity) {
+                  viewModel.updateRecordingConsentStatus(true, needToUpdateLocally: true);
+                } else {
+                  viewModel.resendRecordingConsent(participant.participantId);
+                }
               },
-              icon: const Icon(Icons.refresh, color: Colors.blueAccent),
-              tooltip: "Resend",
+              icon: Icon(
+                participant.participantId == viewModel.participant.identity
+                    ? Icons.check_circle_outline
+                    : Icons.refresh,
+                color: participant.participantId == viewModel.participant.identity
+                    ? Colors.green
+                    : Colors.blueAccent,
+              ),
+              tooltip: participant.participantId == viewModel.participant.identity
+                  ? "Accept"
+                  : "Resend",
             ),
         ],
       ),

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -1267,7 +1267,7 @@ class RtcViewmodel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void updateRecordingConsentStatus(bool status) {
+  void updateRecordingConsentStatus(bool status, {bool needToUpdateLocally = false}) {
     var metadata = room.localParticipant?.metadata;
     Map<String, dynamic> body = {
       "meeting_uid": meetingDetails.meetingUid,
@@ -1281,6 +1281,9 @@ class RtcViewmodel extends ChangeNotifier {
         onSuccess: (data) {
           if (data?.canStartRecording == true) {
             startRecording();
+          }
+          if(needToUpdateLocally) {
+            locallyUpdateRecordingConsentStatus(status);
           }
           sendAction(ActionModel(
               action: MeetingActions.recordingConsentStatus,
@@ -1466,4 +1469,20 @@ class RtcViewmodel extends ChangeNotifier {
     );
     notifyListeners();
   }
+
+  void locallyUpdateRecordingConsentStatus(bool status) {
+    final localId = room.localParticipant?.identity;
+
+    final index = participantListForConsent.indexWhere(
+          (p) => p.participantId == localId,
+    );
+    if (index != -1) {
+      participantListForConsent[index] =
+          participantListForConsent[index].copyWith(
+            consent: status ? "accept" : "reject",
+          );
+      notifyListeners();
+    }
+  }
+
 }


### PR DESCRIPTION
## Description
This PR enhances the recording consent experience with the following improvements:

- **Prevent repeat consent prompts:**  
  Users who have already accepted recording consent will no longer see the consent dialog again when rejoining the meeting.

- **Host and co-host consent handling:**  
  Hosts and co-hosts can now accept recording consent directly from their interface without triggering a consent popup, streamlining their workflow.
