### PR TITLE
fix: empty source language issue for translation

### DIFF
--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -911,13 +911,15 @@ class RtcViewmodel extends ChangeNotifier {
             meetingDetails.authorizationToken, body),
         onSuccess: (data) {
           isTranscriptionLanguageSelected = true;
+          var transcriptionData = TranscriptionActionModel(
+              showIcon: true,
+              isLanguageSelected: true,
+              langCode: selectedLanguage.code,
+              sourceLang: selectedLanguage.code);
+          saveTranscriptionLanguage(transcriptionData);
           sendAction(ActionModel(
               action: MeetingActions.showLiveCaption,
-              liveCaptionsData: TranscriptionActionModel(
-                  showIcon: true,
-                  isLanguageSelected: true,
-                  langCode: selectedLanguage.code,
-                  sourceLang: selectedLanguage.code)));
+              liveCaptionsData: transcriptionData));
           transcriptionEnabled.call();
         },
         onError: (message) => sendMessageToUI(message));


### PR DESCRIPTION
## Description

This PR fixes a bug where the source language for translation was left empty, which could cause translation features to fail or behave unexpectedly.