### PR TITLE
Fix/live-caption-translation

### DIFF
--- a/lib/presentation/dialog/transcript_download_choice_dialog.dart
+++ b/lib/presentation/dialog/transcript_download_choice_dialog.dart
@@ -7,7 +7,8 @@ enum TranscriptDownloadChoice {
 }
 
 class TranscriptDownloadChoiceDialog extends StatelessWidget {
-  const TranscriptDownloadChoiceDialog({super.key});
+  final bool isEnabled;
+  const TranscriptDownloadChoiceDialog({required this.isEnabled, super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -40,15 +41,15 @@ class TranscriptDownloadChoiceDialog extends StatelessWidget {
         ),
         ElevatedButton.icon(
           style: ElevatedButton.styleFrom(
-            backgroundColor: Colors.blue,
+            backgroundColor: isEnabled ? Colors.blue : Colors.blue.withValues(alpha: 0.5),
             foregroundColor: Colors.white,
-            shape:
-                RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
           ),
           icon: const Icon(Icons.translate),
           label: const Text("Translated"),
-          onPressed: () =>
-              Navigator.pop(context, TranscriptDownloadChoice.translated),
+          onPressed: isEnabled
+              ? () => Navigator.pop(context, TranscriptDownloadChoice.translated)
+              : null, // null disables the button
         ),
       ],
     );

--- a/lib/presentation/pages/transcription_screen.dart
+++ b/lib/presentation/pages/transcription_screen.dart
@@ -94,7 +94,7 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> {
     if (isTranslationAllowed) {
       final choice = await showDialog<TranscriptDownloadChoice>(
         context: context,
-        builder: (context) => const TranscriptDownloadChoiceDialog(),
+        builder: (context) => TranscriptDownloadChoiceDialog(isEnabled: widget.viewModel.translationLanguage != null,),
       );
 
       if (choice == null) return;


### PR DESCRIPTION
## 🔒 Fix: Disable "Translated" Button When No Language is Selected

### Description
This PR ensures that the **"Translated"** download button is disabled when the user hasn't selected a translation language.

### Changes
- Disabled the "Translated" button if no translated language is set
- Prevents confusion and incorrect downloads