### PR TITLE
Feat/co-host management

### DIFF
--- a/lib/presentation/dialog/pariticipant_dialog_controls.dart
+++ b/lib/presentation/dialog/pariticipant_dialog_controls.dart
@@ -154,27 +154,33 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
   }
 
   bool isCoHostButtonEnable() {
-    String? myRoleMataData = widget.viewModel.room.localParticipant?.metadata;
-    String? targetRoleMataData = widget.participant.metadata;
+    final String? myMetadata = widget.viewModel.room.localParticipant?.metadata;
+    final String? targetMetadata = widget.participant.metadata;
 
-    bool isHostUser = Utils.isHost(myRoleMataData);
-    bool isTargetNotHost = !Utils.isHost(targetRoleMataData);
-    bool isTargetCoHost = Utils.isCoHost(targetRoleMataData);
+    final bool amIHost = Utils.isHost(myMetadata);
+    final bool amICoHost = Utils.isCoHost(myMetadata);
 
-    // Host can always remove Co-Host
-    if (isHostUser && isTargetCoHost) {
-      return true;
-    }
+    final bool isTargetHost = Utils.isHost(targetMetadata);
+    final bool isTargetCoHost = Utils.isCoHost(targetMetadata);
+    final bool isTargetGuest = !isTargetHost && !isTargetCoHost;
 
-    // Host can make someone co-host
-    if (isHostUser && isTargetNotHost) {
-      if (widget.viewModel.meetingDetails.features?.isAllowMultipleCoHost() == true) {
+    // ❌ Cannot modify the Host
+    if (isTargetHost) return false;
+
+    // ✅ Host or Co-Host can demote a Co-Host
+    if ((amIHost || amICoHost) && isTargetCoHost) return true;
+
+    // ✅ Host or Co-Host can promote a Guest to Co-Host
+    if ((amIHost || amICoHost) && isTargetGuest) {
+      final allowMultiple = widget.viewModel.meetingDetails.features?.isAllowMultipleCoHost() == true;
+      if (allowMultiple) {
         return true;
       } else {
         return widget.viewModel.coHostCount < 1;
       }
     }
 
+    // ❌ In all other cases
     return false;
   }
 


### PR DESCRIPTION
## 🔧 PR: Enable Co-Host Management by Co-Hosts (with Role Restrictions)

### ✅ What’s Changed:
- Updated the `isCoHostButtonEnable()` logic to allow **Co-Hosts** to:
  - Promote participants to Co-Hosts (if allowed by config).
  - Demote existing Co-Hosts.
- Ensured that:
  - **Hosts** can still manage Co-Hosts.
  - **No one (including Co-Hosts)** can modify the Host role.
  - **Participants** (non-Host, non-Co-Host) cannot perform any role changes.

---

### 🔒 Role Permissions Summary:

| Role        | Modify Host | Modify Co-Host | Promote Participant |
|-------------|-------------|----------------|----------------------|
| **Host**    | ❌          | ✅             | ✅                   |
| **Co-Host** | ❌          | ✅             | ✅                   |
| **Participant** | ❌      | ❌             | ❌                   |

---