### PR TITLE
fix: memory leak in lobby request

### DIFF
--- a/lib/rtc/lobby_request_manager.dart
+++ b/lib/rtc/lobby_request_manager.dart
@@ -77,6 +77,12 @@ class LobbyRequestManager {
       Navigator.of(_context).pop();
     }
   }
+
+  void dispose() {
+    _dismissDialog();
+    _lobbyRequestQueue.clear();
+    _isShowingDialog = false;
+  }
 }
 
 class LobbyRequestDialog extends StatelessWidget {

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -156,6 +156,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     viewModel?.stopLobbyCheck();
     viewModel?.cancelRoomEvents();
     meetingManager.cancelMeetingEndScheduler();
+    lobbyManager?.dispose();
     widget.room.disconnect();
     // always dispose listener
     (() async {


### PR DESCRIPTION
### Fix: Memory leak in LobbyRequestManager

- Added `dispose()` method to clear timers and queue.
- Ensures dialog doesn't show after navigating away.
- Call `dispose()` in widget's `dispose()` to clean up properly.