### PR TITLE
fix: add recording consent participant remove functionality

### DIFF
--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -257,6 +257,8 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     })
     ..on<ParticipantDisconnectedEvent>((event) {
       _livekitProviderKey.currentState?.viewModel
+          .removeParticipantFromConsentList(event.participant.identity);
+      _livekitProviderKey.currentState?.viewModel
           .getAttendanceListForParticipant();
       _sortParticipants();
     })


### PR DESCRIPTION
### Summary
This PR fixes an issue where participants who left them meeting they will not visible in the list.

### Changes
- Added logic to remove participants lacking recording consent.
- Ensured removal is triggered immediately when consent is not provided.
