### PR TITLE
fix: restrict full cache clear for other package/app

### DIFF
--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -399,14 +399,14 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
           viewModel?.getAttendanceListForParticipant();
         } else {
           viewModel?.setCoHost(false);
-          StorageHelper().clearAllData();
+          StorageHelper().clearSdkData();
           clearConsentList(viewModel);
         }
         break;
 
       case MeetingActions.removeCoHost:
         viewModel?.setCoHost(false);
-        StorageHelper().clearAllData();
+        StorageHelper().clearSdkData();
         clearConsentList(viewModel);
         break;
 

--- a/lib/utils/storage_helper.dart
+++ b/lib/utils/storage_helper.dart
@@ -2,19 +2,24 @@ import 'package:daakia_vc_flutter_sdk/utils/constants.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class StorageHelper {
+  static const _prefix = "daakia_vc_flutter_sdk."; // Unique prefix for SDK keys
+
   Future<void> saveData(String key, String value) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(key, value);
+    await prefs.setString("$_prefix$key", value);
   }
 
   Future<String?> getData(String key) async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getString(key);
+    return prefs.getString("$_prefix$key");
   }
 
-  Future<void> clearAllData() async {
+  Future<void> clearSdkData() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.clear();
+    final keys = prefs.getKeys().where((k) => k.startsWith(_prefix)).toList();
+    for (final key in keys) {
+      await prefs.remove(key);
+    }
   }
 
   Future<void> setMeetingUid(String value) async => await saveData(Constant.meetingUid, value);


### PR DESCRIPTION
### Summary
This PR updates cache-clearing logic to ensure that clearing operations are scoped only to the current package, preventing unintended data removal from other packages or apps.

### Changes
- Modified cache-clearing function to target only the app’s own cache directory.
- Added safeguards to avoid affecting external package or app data.