### PR TITLE
Fix/keyboard hide issue in iOS

### DIFF
--- a/lib/presentation/pages/chat_page.dart
+++ b/lib/presentation/pages/chat_page.dart
@@ -89,6 +89,7 @@ class _ChatState extends State<ChatPage> {
                         icon: const Icon(Icons.attach_file),
                         color: Colors.white,
                         onPressed: () async {
+                          Utils.hideKeyboard(context);
                           try {
                             widget.viewModel.sendMainChatControllerEvent(ShowLoading());
                             FilePickerResult? result = await FilePicker.platform.pickFiles(
@@ -197,6 +198,7 @@ class _ChatState extends State<ChatPage> {
                         icon: const Icon(Icons.send),
                         color: Colors.white,
                         onPressed: () {
+                          Utils.hideKeyboard(context);
                           setState(() {
                             if (messageController.text.isEmpty) return;
                             widget.viewModel.sendPublicMessage(messageController.text);

--- a/lib/presentation/pages/private_chat_page.dart
+++ b/lib/presentation/pages/private_chat_page.dart
@@ -193,6 +193,7 @@ class PrivateChantState extends State<PrivateChatPage> {
                               icon: const Icon(Icons.attach_file),
                               color: Colors.white,
                               onPressed: () async {
+                                Utils.hideKeyboard(context);
                                 try {
                                   widget.viewModel.sendMainChatControllerEvent(ShowLoading());
                                   FilePickerResult? result = await FilePicker.platform.pickFiles(
@@ -306,6 +307,7 @@ class PrivateChantState extends State<PrivateChatPage> {
                               icon: const Icon(Icons.send),
                               color: Colors.white,
                               onPressed: () {
+                                Utils.hideKeyboard(context);
                                 setState(() {
                                   if (messageController.text.isEmpty) return;
                                   widget.viewModel.sendPrivateMessage(

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -76,13 +76,11 @@ class Utils {
     if (fullName == null || fullName.trim().isEmpty) return "U";
 
     // Split the full name by spaces and filter out empty parts
-    List<String> nameParts = fullName.trim().split(" ").where((part) => part.isNotEmpty).toList();
+    List<String> nameParts =
+        fullName.trim().split(" ").where((part) => part.isNotEmpty).toList();
 
     // Get up to the first two initials, capitalize them, and join
-    return nameParts
-        .take(2)
-        .map((part) => part[0].toUpperCase())
-        .join();
+    return nameParts.take(2).map((part) => part[0].toUpperCase()).join();
   }
 
   static Color generateUniqueColorFromInitials(String initials) {
@@ -327,7 +325,7 @@ class Utils {
     for (var entry in transcriptions) {
       if (entry.isFinal) {
         final String textToUse = (entry.translatedTranscription != null &&
-            entry.translatedTranscription!.trim().isNotEmpty)
+                entry.translatedTranscription!.trim().isNotEmpty)
             ? (entry.translatedTranscription ?? "")
             : entry.transcription;
 
@@ -339,7 +337,6 @@ class Utils {
     }
     return contentBuffer.toString();
   }
-
 
   static Future<SavedData> saveDataToFile(String data, String fileName) async {
     try {
@@ -402,9 +399,14 @@ class Utils {
     return encodedMessage.length <= Constant.maxMessageSize;
   }
 
-  static String generateWhiteboardUrl({required String meetingId,
+  static String generateWhiteboardUrl({
+    required String meetingId,
     required String livekitToken,
   }) {
     return '${Constant.whiteboardDomain}whiteboard/$meetingId?token=$livekitToken';
+  }
+
+  static void hideKeyboard(BuildContext context) {
+    FocusScope.of(context).unfocus();
   }
 }


### PR DESCRIPTION
# Fix Keyboard Hide Issue in Chat & Add Utility Function

## Summary
This PR introduces a utility function to hide the keyboard and resolves a keyboard hide issue in the chat section.

## Changes
- **Feat:** Added `hideKeyboard()` utility function for easier and reusable keyboard dismissal.
- **Fix:** Resolved issue where the keyboard would not hide properly in the chat section.

## Impact
- Improves user experience by ensuring the keyboard hides consistently when required.
- Encourages code reuse with a dedicated `hideKeyboard()` util.
