### PR TITLE
Fix/Restrict Initials to First Two Characters

### DIFF
--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -75,12 +75,21 @@ class Utils {
     // Return "U" if the full name is null or empty
     if (fullName == null || fullName.trim().isEmpty) return "U";
 
-    // Split the full name by spaces and filter out empty parts
-    List<String> nameParts =
-        fullName.trim().split(" ").where((part) => part.isNotEmpty).toList();
+    // Split the name into parts, ignoring extra spaces
+    List<String> nameParts = fullName
+        .trim()
+        .split(RegExp(r'\s+')) // handles multiple spaces
+        .where((part) => part.isNotEmpty)
+        .toList();
 
-    // Get up to the first two initials, capitalize them, and join
-    return nameParts.take(2).map((part) => part[0].toUpperCase()).join();
+    // Take only the first alphabet of the first two words
+    String initials = nameParts
+        .take(2)
+        .map((part) => part[0].toUpperCase())
+        .join();
+
+    // Ensure it's restricted to 2 characters max
+    return initials.length > 2 ? initials.substring(0, 2) : initials;
   }
 
   static Color generateUniqueColorFromInitials(String initials) {


### PR DESCRIPTION
# Restrict Initials to First Two Characters

## Summary
This PR updates the `getInitials` utility to ensure that only the first alphabet of the first two words in a name is returned, restricted to a maximum of two characters.

## Changes
- **Fix:** Enforced rule to display only the first letters of the first two words in a name.
- **Fix:** Restricted initials to a maximum of two uppercase characters.
- **Improvement:** Handles multiple spaces and trims unnecessary whitespace.

## Impact
- Names like `John Doe Smith` will now correctly display as `JD`.
- Prevents overly long or incorrect initials from appearing in the UI.
