### PR TITLE
Feat/data-dog-logs

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -184,6 +184,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.3+hotfix.2"
+  datadog_flutter_plugin:
+    dependency: transitive
+    description:
+      name: datadog_flutter_plugin
+      sha256: cd605d4e455c1dbb96085fdc3e23d01b85b4ec5df3317ce38ea185f8e7686f95
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.12.0"
   dbus:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "8a68739d3ee113e51ad35583fdf9ab82c55d09d693d3c39da1aebab87c938412"
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.5"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -204,18 +204,18 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: "72d146c6d7098689ff5c5f66bcf593ac11efc530095385356e131070333e64da"
+      sha256: "98f28b42168cc509abc92f88518882fd58061ea372d7999aecc424345c7bff6a"
       url: "https://pub.dev"
     source: hosted
-    version: "11.3.0"
+    version: "11.5.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
-      sha256: "0b04e02b30791224b31969eb1b50d723498f402971bff3630bca2ba839bd1ed2"
+      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.2"
+    version: "7.0.3"
   dio:
     dependency: transitive
     description:
@@ -252,10 +252,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -395,10 +395,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   http_parser:
     dependency: transitive
     description:
@@ -1160,18 +1160,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: daf97c9d80197ed7b619040e86c8ab9a9dad285e7671ee7390f9180cc828a51e
+      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
       url: "https://pub.dev"
     source: hosted
-    version: "5.10.1"
+    version: "5.14.0"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "21ec76dfc731550fd3e2ce7a33a9ea90b828fdf19a5c3bcf556fa992cfa99852"
+      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.5"
+    version: "2.1.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1189,5 +1189,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.8.0 <4.0.0"
+  flutter: ">=3.29.0"

--- a/lib/events/rtc_events.dart
+++ b/lib/events/rtc_events.dart
@@ -40,4 +40,7 @@ class UpdateView extends RTCEvents{}
 
 class EnterPIP extends RTCEvents{}
 
-class EndMeeting extends RTCEvents{}
+class EndMeeting extends RTCEvents{
+  final String reason;
+  EndMeeting({required this.reason});
+}

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -16,6 +16,7 @@ import 'package:daakia_vc_flutter_sdk/rtc/widgets/pip_screen.dart';
 import 'package:daakia_vc_flutter_sdk/rtc/widgets/rtc_controls.dart';
 import 'package:daakia_vc_flutter_sdk/rtc/widgets/white_board_widget.dart';
 import 'package:daakia_vc_flutter_sdk/utils/constants.dart';
+import 'package:daakia_vc_flutter_sdk/utils/datadog_disconnect_logger.dart';
 import 'package:daakia_vc_flutter_sdk/utils/datadog_reconnect_logger.dart';
 import 'package:daakia_vc_flutter_sdk/utils/rtc_ext.dart';
 import 'package:daakia_vc_flutter_sdk/utils/storage_helper.dart';
@@ -220,6 +221,10 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     })
     ..on<RoomDisconnectedEvent>((event) async {
       if (event.reason != null) {
+        DatadogDisconnectLogger.logDisconnectEvent(
+            meetingId: widget.meetingDetails.meetingUid,
+            room: widget.room,
+            reason: event.reason?.name);
         _livekitProviderKey.currentState?.viewModel.isMeetingEnded = true;
         switch (event.reason) {
           case DisconnectReason.participantRemoved:
@@ -989,6 +994,11 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
           setState(() {});
         }
       } else if (event is EndMeeting) {
+        DatadogDisconnectLogger.logDisconnectEvent(
+            meetingId: widget.meetingDetails.meetingUid,
+            room: widget.room,
+            reason: event.reason
+        );
         if (mounted) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             closeMeetingProgrammatically(context);
@@ -1057,6 +1067,10 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     if (viewModel?.meetingDetails.meetingBasicDetails?.meetingConfig
             ?.autoMeetingEnd ==
         1) {
+      DatadogDisconnectLogger.logDisconnectEvent(
+          meetingId: widget.meetingDetails.meetingUid,
+          room: widget.room,
+          reason: "TIME_EXCEEDED");
       showSnackBar(message: "Meeting ended");
       Timer(const Duration(seconds: 3), () {
         if (mounted) {
@@ -1068,6 +1082,10 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
       return;
     }
     if (viewModel?.meetingDetails.features?.isBasicPlan() == true) {
+      DatadogDisconnectLogger.logDisconnectEvent(
+          meetingId: widget.meetingDetails.meetingUid,
+          room: widget.room,
+          reason: "TIME_EXCEEDED");
       showSnackBar(message: "Meeting ended");
       Timer(const Duration(seconds: 3), () {
         if (mounted) {

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -16,6 +16,7 @@ import 'package:daakia_vc_flutter_sdk/rtc/widgets/pip_screen.dart';
 import 'package:daakia_vc_flutter_sdk/rtc/widgets/rtc_controls.dart';
 import 'package:daakia_vc_flutter_sdk/rtc/widgets/white_board_widget.dart';
 import 'package:daakia_vc_flutter_sdk/utils/constants.dart';
+import 'package:daakia_vc_flutter_sdk/utils/datadog_reconnect_logger.dart';
 import 'package:daakia_vc_flutter_sdk/utils/rtc_ext.dart';
 import 'package:daakia_vc_flutter_sdk/utils/storage_helper.dart';
 import 'package:daakia_vc_flutter_sdk/viewmodel/rtc_provider.dart';
@@ -340,6 +341,13 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
           '[Livekit] - Attempting to reconnect ${event.attempt}/${event.maxAttemptsRetry}, '
           '(${event.nextRetryDelaysInMs}ms delay until next attempt)');
       onReconnectStart();
+      DatadogReconnectLogger.logReconnectEvent(
+          meetingId: widget.meetingDetails.meetingUid,
+          room: widget.room,
+          state: "RoomAttemptReconnectEvent",
+          attempt: event.attempt,
+          maxAttempts: event.maxAttemptsRetry,
+          delayMs: event.nextRetryDelaysInMs);
     })
     ..on<LocalTrackSubscribedEvent>((event) {
       if (kDebugMode) {
@@ -964,6 +972,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     if (isEventAdded) return;
     isEventAdded = true;
     viewModel?.roomEvents.listen((event) {
+      if (!context.mounted) return;
       if (event is ShowSnackBar) {
         showSnackBar(message: event.message);
       } else if (event is ShowTranscriptionDownload) {

--- a/lib/rtc/widgets/rtc_controls.dart
+++ b/lib/rtc/widgets/rtc_controls.dart
@@ -195,7 +195,7 @@ class _RtcControlState extends State<RtcControls> {
     final result = await context.showDisconnectDialog();
     if (result == true) {
       viewModel.isMeetingEnded = true;
-      viewModel.sendEvent(EndMeeting());
+      viewModel.sendEvent(EndMeeting(reason: "clientInitiated"));
     }
   }
 
@@ -214,7 +214,7 @@ class _RtcControlState extends State<RtcControls> {
           },
           onLeaveCall: () {
             Navigator.pop(context); // Close the BottomSheet
-            viewModel.sendEvent(EndMeeting());
+            viewModel.sendEvent(EndMeeting(reason: "clientInitiated"));
           },
         );
       },

--- a/lib/service/daakia_vc_datadog_service.dart
+++ b/lib/service/daakia_vc_datadog_service.dart
@@ -1,0 +1,63 @@
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+
+class DaakiaVcDatadogService {
+  static DatadogLogger? _logger;
+
+  static Future<void> initialize({
+    required String clientToken,
+    required String env,
+    required String serviceName,
+    required String applicationId,
+    required String? version,
+    DatadogSite site = DatadogSite.us3,
+    bool enableCrashReporting = true,
+  }) async {
+    final configuration = DatadogConfiguration(
+      clientToken: clientToken,
+      env: env,
+      site: site,
+      service: serviceName,
+      version: version,
+      nativeCrashReportEnabled: enableCrashReporting,
+      loggingConfiguration: DatadogLoggingConfiguration(),
+      rumConfiguration: DatadogRumConfiguration(
+        applicationId: applicationId,
+        sessionSamplingRate: 100,
+        trackAnonymousUser: true,
+      ),
+    );
+
+    await DatadogSdk.runApp(configuration, TrackingConsent.granted, () async {});
+
+    _logger = DatadogSdk.instance.logs?.createLogger(
+      DatadogLoggerConfiguration(remoteLogThreshold: LogLevel.info),
+    );
+  }
+
+  // --- Logging Methods ---
+  static void logDebug(String message, {Map<String, Object?>? attributes}) {
+    _logger?.debug(message, attributes: attributes ?? {});
+  }
+
+  static void logInfo(String message, {Map<String, Object?>? attributes}) {
+    _logger?.info(message, attributes: attributes ?? {});
+  }
+
+  static void logWarning(String message, {Map<String, Object?>? attributes}) {
+    _logger?.warn(message, attributes: attributes ?? {});
+  }
+
+  static void logError(
+      String message, [
+        Object? error,
+        StackTrace? stackTrace,
+        Map<String, Object?>? attributes,
+      ]) {
+    _logger?.error(
+      message,
+      errorMessage: error?.toString(),
+      errorStackTrace: stackTrace,
+      attributes: attributes ?? {},
+    );
+  }
+}

--- a/lib/utils/datadog_disconnect_logger.dart
+++ b/lib/utils/datadog_disconnect_logger.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:livekit_client/livekit_client.dart';
+
+import '../service/daakia_vc_datadog_service.dart';
+import 'device_network_info.dart';
+
+class DatadogDisconnectLogger {
+  static Future<void> logDisconnectEvent({
+    required String meetingId,
+    required Room room,
+    required String? reason,
+  }) async {
+    final local = room.localParticipant;
+
+    Map<String, dynamic> metadataJson = {};
+    try {
+      if (local?.metadata != null) {
+        metadataJson = Map<String, dynamic>.from(
+          jsonDecode(local!.metadata!),
+        );
+      }
+    } catch (_) {
+      // Ignore metadata parsing errors
+    }
+
+    final attributes = <String, Object?>{
+      'meetingId': meetingId,
+      'disconnectReason': _formatDisconnectReason(reason),
+      'participant': {
+        'name': local?.name,
+        'identity': local?.identity,
+        'metadata': local?.metadata,
+        'role': metadataJson['role_name'],
+        'meetingAttendanceId': metadataJson['meeting_attendance_id'],
+        'connectionQuality': local?.connectionQuality.name,
+        'isSpeaking': local?.isSpeaking,
+        'platform': defaultTargetPlatform.name,
+        'userAgent': await DeviceNetworkInfo.getDeviceDetails(),
+        'network': await DeviceNetworkInfo.getNetworkType()
+      }
+    };
+
+    DaakiaVcDatadogService.logInfo(
+      'DISCONNECT REASON: ${_formatDisconnectReason(reason)}',
+      attributes: attributes,
+    );
+  }
+
+  static String _formatDisconnectReason(String? reason) {
+    if (reason == null) return "UNKNOWN";
+    // Convert camelCase → SNAKE_CASE
+    final snake = reason.replaceAllMapped(
+      RegExp(r'([a-z0-9])([A-Z])'),
+      (match) => '${match.group(1)}_${match.group(2)}',
+    );
+
+    return snake.toUpperCase();
+  }
+}

--- a/lib/utils/datadog_logger_helper.dart
+++ b/lib/utils/datadog_logger_helper.dart
@@ -1,0 +1,44 @@
+import 'package:daakia_vc_flutter_sdk/service/daakia_vc_datadog_service.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/cupertino.dart';
+
+enum DatadogLogLevel { debug, info, warn, error }
+
+class DatadogLoggerHelper {
+  static void saveDatadogLog({
+    required DatadogLogLevel level,
+    required String message,
+    required RequestOptions? requestOptions,
+    required DioException? dioException,
+    dynamic payload,
+  }) {
+
+    if (message.isEmpty) message = "Something";
+
+    final data = <String, Object?>{
+      'endpoint': requestOptions?.path,
+      'method': requestOptions?.method,
+      if (payload != null) 'payload': payload,
+      if (dioException?.response?.data != null) 'response': dioException?.response?.data,
+    };
+
+    try {
+      switch (level) {
+        case DatadogLogLevel.debug:
+          DaakiaVcDatadogService.logDebug(message, attributes: data);
+          break;
+        case DatadogLogLevel.info:
+          DaakiaVcDatadogService.logInfo(message, attributes: data);
+          break;
+        case DatadogLogLevel.warn:
+          DaakiaVcDatadogService.logWarning(message, attributes: data);
+          break;
+        case DatadogLogLevel.error:
+          DaakiaVcDatadogService.logError(message, dioException, dioException?.stackTrace, data);
+          break;
+      }
+    } catch (error) {
+      debugPrint("Datadog fallback log [$level]: $message - $data");
+    }
+  }
+}

--- a/lib/utils/datadog_reconnect_logger.dart
+++ b/lib/utils/datadog_reconnect_logger.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:daakia_vc_flutter_sdk/service/daakia_vc_datadog_service.dart';
+import 'package:daakia_vc_flutter_sdk/utils/device_network_info.dart';
+import 'package:flutter/foundation.dart';
+import 'package:livekit_client/livekit_client.dart';
+
+class DatadogReconnectLogger {
+  static Future<void> logReconnectEvent({
+    required String meetingId,
+    required Room room,
+    required String state, // "attempt", "reconnected", "disconnected"
+    int? attempt,
+    int? maxAttempts,
+    int? delayMs,
+  }) async {
+    final local = room.localParticipant;
+
+    Map<String, dynamic> metadataJson = {};
+    try {
+      if (local?.metadata != null) {
+        metadataJson = Map<String, dynamic>.from(
+          jsonDecode(local!.metadata!),
+        );
+      }
+    } catch (_) {
+      // Ignore metadata parsing errors
+    }
+
+    final attributes = <String, Object?>{
+      'meetingId': meetingId,
+      'state': state,
+      if (attempt != null) 'attempt': attempt,
+      if (maxAttempts != null) 'maxAttempts': maxAttempts,
+      if (delayMs != null) 'nextRetryDelayMs': delayMs,
+      'participantAttendanceId': metadataJson['meeting_attendance_id'],
+      'participant': {
+        'name': local?.name,
+        'identity': local?.identity,
+        'metadata': local?.metadata,
+        'role': metadataJson['role_name'],
+        'meetingAttendanceId': metadataJson['meeting_attendance_id'],
+        'connectionQuality': local?.connectionQuality.name,
+        'isSpeaking': local?.isSpeaking,
+        'platform': defaultTargetPlatform.name,
+        'userAgent': await DeviceNetworkInfo.getDeviceDetails(),
+        'network': await DeviceNetworkInfo.getNetworkType()
+      }
+    };
+    DaakiaVcDatadogService.logError(
+      'Reconnecting to the room!!!',
+      null,
+      null,
+      attributes,
+    );
+  }
+}

--- a/lib/utils/device_network_info.dart
+++ b/lib/utils/device_network_info.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+
+class DeviceNetworkInfo {
+  static final DeviceInfoPlugin _deviceInfo = DeviceInfoPlugin();
+
+  /// Get userAgent equivalent: device + OS version
+  static Future<String> getDeviceDetails() async {
+    if (Platform.isAndroid) {
+      final info = await _deviceInfo.androidInfo;
+      return 'Android ${info.version.release} (SDK ${info.version.sdkInt}), ${info.manufacturer} ${info.model}';
+    } else if (Platform.isIOS) {
+      final info = await _deviceInfo.iosInfo;
+      return 'iOS ${info.systemVersion}, ${info.name} (${info.model})';
+    }
+    return '${Platform.operatingSystem} ${Platform.operatingSystemVersion}';
+  }
+
+  /// Get network type: wifi, mobile, ethernet, none
+  static Future<String> getNetworkType() async {
+    final results = await Connectivity().checkConnectivity();
+    if (results.contains(ConnectivityResult.mobile)) {
+      return 'mobile'; // optionally refine 3G/4G/5G
+    } else if (results.contains(ConnectivityResult.wifi)) {
+      return 'wifi';
+    } else if (results.contains(ConnectivityResult.ethernet)) {
+      return 'ethernet';
+    } else if (results.contains(ConnectivityResult.none)) {
+      return 'no-internet';
+    } else {
+      return 'unknown';
+    }
+  }
+
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -440,5 +440,11 @@ class Utils {
     return null;
   }
 
+  static String extractMessage(String prefix, dynamic data, String fallback) {
+    if (data is Map<String, dynamic> && data['message'] != null) {
+      return "$prefix ${data['message']}";
+    }
+    return "$prefix $fallback";
+  }
 
 }

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -1163,7 +1163,7 @@ class RtcViewmodel extends ChangeNotifier {
     };
     networkRequestHandler(
       apiCall: () => apiClient.endMeeting(body),
-      onSuccess: (_) => sendEvent(EndMeeting()),
+      onSuccess: (_) => sendEvent(EndMeeting(reason: "roomDeleted")),
       onError: (message) => sendMessageToUI(message),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -218,13 +218,13 @@ packages:
     source: hosted
     version: "1.19.1"
   connectivity_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "04bf81bb0b77de31557b58d052b24b3eee33f09a6e7a8c68a3e247c7df19ec27"
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.3"
+    version: "6.1.5"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -298,21 +298,21 @@ packages:
     source: hosted
     version: "0.7.11"
   device_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "306b78788d1bb569edb7c55d622953c2414ca12445b41c9117963e03afc5c513"
+      sha256: "98f28b42168cc509abc92f88518882fd58061ea372d7999aecc424345c7bff6a"
       url: "https://pub.dev"
     source: hosted
-    version: "11.3.3"
+    version: "11.5.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
-      sha256: "0b04e02b30791224b31969eb1b50d723498f402971bff3630bca2ba839bd1ed2"
+      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.2"
+    version: "7.0.3"
   dio:
     dependency: "direct main"
     description:
@@ -500,10 +500,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -1439,4 +1439,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.29.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -281,6 +281,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.3+hotfix.2"
+  datadog_flutter_plugin:
+    dependency: "direct main"
+    description:
+      name: datadog_flutter_plugin
+      sha256: cd605d4e455c1dbb96085fdc3e23d01b85b4ec5df3317ce38ea185f8e7686f95
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.12.0"
   dbus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,8 @@ dependencies:
   webview_flutter_wkwebview: ^3.18.5
   audioplayers: ^6.5.0
   datadog_flutter_plugin: ^2.11.0
+  connectivity_plus: ^6.1.5
+  device_info_plus: ^11.5.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   webview_flutter_android: ^4.3.0
   webview_flutter_wkwebview: ^3.18.5
   audioplayers: ^6.5.0
+  datadog_flutter_plugin: ^2.11.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## ✨ New Features
- Integrated **Datadog dependency** into the project.  
- Added `daakia_vc_datadog_service.dart` for centralized Datadog logging.  
- Implemented utility helpers:  
  - `device_network_info.dart` → fetch device & network details.  
  - `datadog_reconnect_logger.dart` → structured reconnect attempt logs.  
  - `datadog_disconnect_logger.dart` → structured disconnect reason logs.  
- Added Datadog logs in API requests for better traceability.  
- Extended **EndMeeting event class** with `reasons` field to capture meeting termination reasons.  