### PR TITLE
Feat/restrict multiple screen share

### DIFF
--- a/lib/model/action_model.dart
+++ b/lib/model/action_model.dart
@@ -1,4 +1,5 @@
 import 'package:daakia_vc_flutter_sdk/model/transcription_action_model.dart';
+
 import 'consent_participant.dart';
 
 class ActionModel {
@@ -9,18 +10,23 @@ class ActionModel {
   final TranscriptionActionModel? liveCaptionsData;
   final String? consent;
   final List<ConsentParticipant>? participants;
-  final Map<String, dynamic>? user; // <-- new field
+  final Map<String, dynamic>? user;
+  final int? timeStamp;
 
-  ActionModel({
-    this.action,
-    this.message = "",
-    this.token = "",
-    this.value = true,
-    this.liveCaptionsData,
-    this.consent,
-    this.participants,
-    this.user, // <-- added here
-  });
+  // <-- new field
+
+  ActionModel(
+      {this.action,
+      this.message = "",
+      this.token = "",
+      this.value = true,
+      this.liveCaptionsData,
+      this.consent,
+      this.participants,
+      this.user,
+      this.timeStamp
+      // <-- added here
+      });
 
   // Converts ActionModel to JSON
   Map<String, dynamic> toJson() {
@@ -42,6 +48,9 @@ class ActionModel {
     if (user != null) {
       data['user'] = user;
     }
+    if (timeStamp != null) {
+      data['timeStamp'] = timeStamp;
+    }
     return data;
   }
 
@@ -57,7 +66,9 @@ class ActionModel {
       participants: (json['participants'] as List<dynamic>?)
           ?.map((e) => ConsentParticipant.fromJson(e as Map<String, dynamic>))
           .toList(),
-      user: json['user'] as Map<String, dynamic>?, // <-- added here
+      user: json['user'] as Map<String, dynamic>?,
+      timeStamp: json['timeStamp'] as int?,
+      // <-- added here
     );
   }
 }

--- a/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
@@ -325,6 +325,10 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
     }
 
     await participant?.setScreenShareEnabled(true, captureScreenAudio: true);
+    viewModel.sendAction(ActionModel(
+      action: MeetingActions.screenShareStarted,
+      timeStamp: DateTime.now().microsecondsSinceEpoch
+    ));
   }
 
   void _disableScreenShare(RtcViewmodel viewModel) async {

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -361,6 +361,17 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         print('Local track subscribed: ${event.trackSid}');
       }
     })
+    ..on<TrackPublishedEvent>((track) {
+      var viewModel = _livekitProviderKey.currentState?.viewModel;
+      final localParticipant = widget.room.localParticipant;
+      if (localParticipant?.isScreenShareEnabled() == true) {
+        if (localParticipant?.identity != track.participant.identity) {
+          if (track.participant.isScreenShareEnabled()) {
+            viewModel?.disposeScreenShare();
+          }
+        }
+      }
+    })
     ..on<LocalTrackPublishedEvent>((_) => _sortParticipants())
     ..on<LocalTrackUnpublishedEvent>((_) => _sortParticipants())
     ..on<TrackSubscribedEvent>((_) => _sortParticipants())

--- a/lib/utils/meeting_actions.dart
+++ b/lib/utils/meeting_actions.dart
@@ -56,6 +56,8 @@ class MeetingActions {
 
   static const String startedRecordingConsent = "started-recording-consent";
 
+  static const String screenShareStarted = "screen-share-started";
+
   // ✅ Add new fields here
 
   // ✅ Method to check if an action is valid
@@ -99,6 +101,7 @@ class MeetingActions {
     recordingConsentStatus,
     recordingConsentModal,
     startedRecordingConsent,
+    screenShareStarted,
     // ✅ Add new fields here
   };
 }


### PR DESCRIPTION
## Feat: Restrict multiple screen shares  

### Summary  
Previously, multiple participants could share their screens simultaneously. This caused visibility and UX issues, making it difficult to focus on one shared screen.  

### Changes  
- Restricted screen sharing to **one participant at a time**.  
- If a new participant starts sharing, the previous sharer’s screen is automatically stopped.  

### Impact  
- Improves clarity and meeting experience.  
- Ensures only one active screen share is visible at any given time.  
