### PR TITLE
Fix/minor bug fixes

### DIFF
--- a/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
@@ -251,7 +251,12 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
     final participant = viewModel.room.localParticipant;
 
     if (viewModel.isScreenSharePermissionNeeded()) {
-      viewModel.sendMessageToUI("Screen share request sent to the ${viewModel.getAdminType()}.");
+      final adminType = viewModel.getAdminType();
+      final message = adminType == null
+          ? "No Host or Co-Host available to approve screen sharing."
+          : "Screen share request sent to the $adminType.";
+
+      viewModel.sendMessageToUI(message);
       return;
     }
 

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -1460,6 +1460,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     viewModel?.unregisterCaption();
     handleAndroidNotification(enable: false);
     _disposePip();
+    DaakiaPiP.disposePiP();
   }
 
   void _disposePip() {

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -352,6 +352,8 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     })
     ..on<ParticipantDisconnectedEvent>((event) {
       _livekitProviderKey.currentState?.viewModel
+          .clearScreenShareRequest(event.participant.identity);
+      _livekitProviderKey.currentState?.viewModel
           .removeParticipantFromConsentList(event.participant.identity);
       _livekitProviderKey.currentState?.viewModel
           .getAttendanceListForParticipant();

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2057,7 +2057,7 @@ class RtcViewmodel extends ChangeNotifier {
 
   bool isScreenSharePermissionNeeded() {
     var localParticipant = room.localParticipant;
-    if (Utils.isCoHost(localParticipant?.metadata) || Utils.isCoHost(localParticipant?.metadata)) return false;
+    if (Utils.isHost(localParticipant?.metadata) || Utils.isCoHost(localParticipant?.metadata)) return false;
     if (!_isScreenShareEnable) {
       if (isScreenShareRequestAccepted) return false;
       if(adminList.isEmpty) return true;

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2117,6 +2117,13 @@ class RtcViewmodel extends ChangeNotifier {
     notifyListeners();
   }
 
+  void clearScreenShareRequest(String identity) {
+    _screenShareRequestList.removeWhere(
+          (item) => item.identity?.identity == identity,
+    );
+    notifyListeners();
+  }
+
   bool _isScreenShareDialogOpen = false;
 
   bool get isScreenShareDialogOpen => _isScreenShareDialogOpen;

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2079,12 +2079,12 @@ class RtcViewmodel extends ChangeNotifier {
     }
   }
 
-  String getAdminType() {
-    if(adminList.isEmpty) return "Unknown";
+  String? getAdminType() {
+    if(adminList.isEmpty) return null;
     final metadata = adminList[0]?.metadata;
     if (Utils.isHost(metadata)) return "Host";
     if (Utils.isCoHost(metadata)) return "Co-Host";
-    return "Unknown";
+    return null;
   }
 
   List<RemoteActivityData> _screenShareRequestList = [];


### PR DESCRIPTION
## 🐛 Fixes

### Screen Share & PiP Stability Improvements

- Fixed **PiP memory leak on iOS** after meeting ends.
- Cleared **pending screen-share requests** when a participant disconnects.
- Fixed **screen-share permission handling for Host**.
- Restricted **screen-share permission when no admin is present** to prevent invalid requests.

These changes improve stability, prevent memory leaks, and ensure correct screen-share permission flow.
