### PR TITLE
Feat/skip prejoin

### DIFF
--- a/doc/DaakiaMeetingConfiguration.md
+++ b/doc/DaakiaMeetingConfiguration.md
@@ -1,7 +1,7 @@
 # DaakiaMeetingConfiguration
 
 The `DaakiaMeetingConfiguration` class allows advanced customization for the Daakia Video Conference SDK.  
-It includes optional metadata for participants and participant name behavior.
+It includes optional metadata, participant name behavior, and pre-join flow behavior.
 
 > **Note:** This is optional. If not provided, default behavior will be used.
 
@@ -11,6 +11,7 @@ It includes optional metadata for participants and participant name behavior.
 - [Usage](#usage)
 - [Metadata](#metadata)
 - [Participant Name Configuration](#participant-name-configuration)
+- [Skip Pre-Join Page](#skip-pre-join-page)
 - [Examples](#examples)
 - [Best Practices](#best-practices)
 
@@ -36,6 +37,7 @@ await Navigator.push<void>(
           name: 'John Doe',
           isEditable: false,
         ),
+        skipPreJoinPage: false,
       ),
     ),
   ),
@@ -94,6 +96,30 @@ DaakiaMeetingConfiguration(
 ```
 
 ---
+## Skip Pre-Join Page
+
+The `skipPreJoinPage` flag lets you bypass the interactive pre-join UI and start joining immediately with a loader screen.
+
+### Use Cases
+
+- 1:1 video call flows where camera/mic/name/password setup UI is not needed.
+- Fast join experiences with configuration managed by the host app.
+
+### Example
+
+```dart
+DaakiaMeetingConfiguration(
+  participantNameConfig: ParticipantNameConfig(
+    name: 'Quick Caller',
+    isEditable: false,
+  ),
+  skipPreJoinPage: true,
+);
+```
+
+> ⚠️ If the meeting requires user-entered password/email verification, keep this flag `false` unless your app handles those checks externally.
+
+---
 ## Examples
 
 ### Example 1: Basic Metadata
@@ -129,6 +155,7 @@ DaakiaMeetingConfiguration(
     name: 'John Doe',
     isEditable: true,
   ),
+  skipPreJoinPage: false,
 );
 ```
 

--- a/example/lib/screen/configuration_screen.dart
+++ b/example/lib/screen/configuration_screen.dart
@@ -19,6 +19,7 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
 
   bool _customizeConfigName = false;
   bool _isNameEditable = true;
+  bool _skipPreJoinPage = false;
   final TextEditingController _configNameController = TextEditingController();
 
   void _addMetadataField() {
@@ -72,6 +73,7 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
                 : _isNameEditable)
             : true,
       ),
+      skipPreJoinPage: _skipPreJoinPage,
     );
   }
 
@@ -100,6 +102,8 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
           );
         }
       }
+
+      _skipPreJoinPage = config.skipPreJoinPage == true;
     }
   }
 
@@ -187,6 +191,18 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
                           if (!value) {
                             _metadataControllers.clear();
                           }
+                        });
+                      },
+                    ),
+                    SwitchListTile(
+                      title: const Text("Skip Pre-Join Page"),
+                      subtitle: const Text(
+                        "Directly join with loader screen (no pre-join UI)",
+                      ),
+                      value: _skipPreJoinPage,
+                      onChanged: (value) {
+                        setState(() {
+                          _skipPreJoinPage = value;
                         });
                       },
                     ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.2+2
 
 environment:
   sdk: ^3.5.3

--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -98,6 +98,7 @@ abstract class RestClient {
     @Body() Map<String, dynamic> body,
   );
 
+  @Deprecated("No longer needed the dispatch id")
   @GET("rtc/recording/dispatchId")
   Future<BaseResponse<RecordingDispatchData>> getRecordingDispatchedId(
       @Header("Authorization") String token,

--- a/lib/model/daakia_meeting_configuration.dart
+++ b/lib/model/daakia_meeting_configuration.dart
@@ -22,6 +22,17 @@ class DaakiaMeetingConfiguration {
   /// If `name` is not provided or is empty, the name field will always be editable.
   final ParticipantNameConfig? participantNameConfig;
 
+  /// When true, the SDK skips rendering the interactive pre-join UI and
+  /// directly starts the join flow with a loader screen.
+  ///
+  /// Use this for 1:1 or quick-call style experiences where pre-join controls
+  /// are not required.
+  ///
+  /// Note:
+  /// - Meetings that require participant credential input (password/email)
+  ///   should keep this false, unless those checks are handled externally.
+  final bool? skipPreJoinPage;
+
   /// Defines configuration settings for initializing and customizing
   /// a Daakia meeting session.
   ///
@@ -47,6 +58,7 @@ class DaakiaMeetingConfiguration {
   const DaakiaMeetingConfiguration({
     this.metadata,
     this.participantNameConfig,
+    this.skipPreJoinPage,
     this.vcConfig,
   });
 }

--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -685,12 +685,15 @@ class _PreJoinState extends State<PreJoinScreen> {
           livekitToken: livekitToken,
           features: features,
           meetingBasicDetails: widget.basicMeetingDetails);
-      if (context.mounted) {
-        await Navigator.push<void>(
-          context,
+      if (mounted) {
+        final navigator = Navigator.of(this.context);
+        await navigator.push<void>(
           MaterialPageRoute(
               builder: (_) => RoomPage(room, listener, meetingDetails)),
         );
+        if (mounted && navigator.canPop()) {
+          navigator.pop();
+        }
       }
     } catch (error) {
       if (kDebugMode) {

--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -70,6 +70,8 @@ class _PreJoinState extends State<PreJoinScreen> {
 
   TextEditingController? _nameController;
   bool _isNameEditable = true;
+  bool _autoJoinStarted = false;
+  String _skipJoinErrorMessage = "";
 
   //============== RTC ===============
   StreamSubscription? _subscription;
@@ -95,14 +97,93 @@ class _PreJoinState extends State<PreJoinScreen> {
     Hardware.instance.enumerateDevices().then(_loadDevices);
     setUserName();
     // Schedule verifyCoHost after widget is built
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      verifyCoHost();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await verifyCoHost();
       meetingManager = MeetingManager(
           endDate: getMeetingEndDate(),
           endMeetingCallBack: (event) {},
           context: context);
+      unawaited(_startAutoJoinIfRequired());
     });
     super.initState();
+  }
+
+  bool get _shouldSkipPreJoin => widget.configuration?.skipPreJoinPage == true;
+
+  Future<void> _startAutoJoinIfRequired() async {
+    if (!_shouldSkipPreJoin || _autoJoinStarted || !mounted) {
+      return;
+    }
+
+    _autoJoinStarted = true;
+    _skipJoinErrorMessage = "";
+    isNeedToCancelApiCall = false;
+
+    if (name.trim().isEmpty) {
+      final resolvedName = await getUserName();
+      if (!mounted) return;
+      name = resolvedName.trim().isNotEmpty ? resolvedName : "Guest";
+      _nameController?.text = name;
+    }
+
+    final validationError = _getSkipPreJoinValidationError();
+    if (validationError != null) {
+      _skipJoinErrorMessage = validationError;
+      isLoading = false;
+      if (mounted) {
+        setState(() {});
+      }
+      return;
+    }
+
+    isLoading = true;
+    if (mounted) {
+      setState(() {});
+    }
+
+    if (widget.isHost && !isHostVerified) {
+      final token = widget.configuration?.vcConfig?.hostToken;
+      if (token != null && token.isNotEmpty) {
+        hostToken = token;
+        isHostVerified = true;
+        getFeaturesAndJoinMeeting(_autoStopLoading);
+        return;
+      }
+      _getHostToken(_autoStopLoading);
+      return;
+    }
+
+    checkMeetingType(_autoStopLoading);
+  }
+
+  String? _getSkipPreJoinValidationError() {
+    if (_isCoHostVerified) {
+      return null;
+    }
+    if (widget.isHost &&
+        widget.basicMeetingDetails?.hostPinVerificationRequired == 1 &&
+        (widget.configuration?.vcConfig?.hostToken?.isEmpty ?? true)) {
+      return "Host verification is required. Please provide host token in configuration or disable skipPreJoinPage.";
+    }
+    if (!widget.isHost &&
+        widget.basicMeetingDetails?.isStandardPassword == true) {
+      return "This meeting requires email/password verification. Disable skipPreJoinPage for this meeting type.";
+    }
+    if (!widget.isHost &&
+        widget.basicMeetingDetails?.isCommonPassword == true) {
+      return "This meeting requires a password. Disable skipPreJoinPage for this meeting type.";
+    }
+    return null;
+  }
+
+  void _autoStopLoading() {
+    isLoading = false;
+    if (!mounted) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        setState(() {});
+      }
+    });
   }
 
   void setUserName() async {
@@ -284,6 +365,9 @@ class _PreJoinState extends State<PreJoinScreen> {
         }
       },
       onError: (message) {
+        if (_shouldSkipPreJoin) {
+          _skipJoinErrorMessage = message;
+        }
         setState(() {
           isLoading = false;
           isNeedToCancelApiCall = true;
@@ -309,6 +393,9 @@ class _PreJoinState extends State<PreJoinScreen> {
 
   void _handleRejection(Function stopLoading) {
     isRejected = true;
+    if (_shouldSkipPreJoin) {
+      _skipJoinErrorMessage = alertMessage;
+    }
     stopLoading.call();
     if (mounted) {
       setState(() => Utils.showSnackBar(context, message: alertMessage));
@@ -334,6 +421,9 @@ class _PreJoinState extends State<PreJoinScreen> {
           getFeaturesAndJoinMeeting(stopLoading);
         },
         onError: (message) {
+          if (_shouldSkipPreJoin) {
+            _skipJoinErrorMessage = message;
+          }
           if (mounted) {
             Utils.showSnackBar(context, message: message);
           }
@@ -371,6 +461,9 @@ class _PreJoinState extends State<PreJoinScreen> {
           });
         },
         onError: (message) {
+          if (_shouldSkipPreJoin) {
+            _skipJoinErrorMessage = message;
+          }
           if (mounted) {
             Utils.showSnackBar(context, message: message);
           }
@@ -399,6 +492,9 @@ class _PreJoinState extends State<PreJoinScreen> {
           startAddingParticipantsPool(stopLoading);
         },
         onError: (message) {
+          if (_shouldSkipPreJoin) {
+            _skipJoinErrorMessage = message;
+          }
           if (mounted) {
             Utils.showSnackBar(context, message: message);
           }
@@ -600,6 +696,9 @@ class _PreJoinState extends State<PreJoinScreen> {
       if (kDebugMode) {
         print('Could not connect $error');
       }
+      if (_shouldSkipPreJoin) {
+        _skipJoinErrorMessage = error.toString();
+      }
       if (context.mounted) {
         await context.showErrorDialog(error);
       }
@@ -613,6 +712,10 @@ class _PreJoinState extends State<PreJoinScreen> {
 
   @override
   Widget build(BuildContext context) {
+    if (_shouldSkipPreJoin) {
+      return _buildSkipPreJoinLoader();
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text(
@@ -897,7 +1000,7 @@ class _PreJoinState extends State<PreJoinScreen> {
 
                             if (token != null && token.isNotEmpty) {
                               hostToken = token;
-                              isHostVerified == true;
+                              isHostVerified = true;
                               isNeedToCancelApiCall = false;
                               getFeaturesAndJoinMeeting(stopLoading);
                               return;
@@ -921,6 +1024,61 @@ class _PreJoinState extends State<PreJoinScreen> {
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildSkipPreJoinLoader() {
+    final hasError = _skipJoinErrorMessage.trim().isNotEmpty;
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (isLoading) ...[
+                  const CircularProgressIndicator(color: themeColor),
+                  const SizedBox(height: 16),
+                  const Text(
+                    "Joining call...",
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                  ),
+                ],
+                if (!isLoading && hasError) ...[
+                  Text(
+                    _skipJoinErrorMessage,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(color: Colors.red, fontSize: 14),
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ElevatedButton(
+                        onPressed: () {
+                          _autoJoinStarted = false;
+                          unawaited(_startAutoJoinIfRequired());
+                        },
+                        child: const Text("Retry"),
+                      ),
+                      const SizedBox(width: 10),
+                      OutlinedButton(
+                        onPressed: () {
+                          if (mounted) {
+                            Navigator.of(context).pop();
+                          }
+                        },
+                        child: const Text("Back"),
+                      ),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }
@@ -984,6 +1142,9 @@ class _PreJoinState extends State<PreJoinScreen> {
           }
         },
         onError: (message) {
+          if (_shouldSkipPreJoin) {
+            _skipJoinErrorMessage = message;
+          }
           setState(() {
             isLoading = false;
             isNeedToCancelApiCall = true;
@@ -1199,7 +1360,13 @@ class _PreJoinState extends State<PreJoinScreen> {
 
   void passwordNotVerified(Function stopLoading,
       {String message = "Something went wrong!"}) {
+    if (_shouldSkipPreJoin) {
+      _skipJoinErrorMessage = message;
+    }
     stopLoading();
+    if (_shouldSkipPreJoin && mounted) {
+      setState(() {});
+    }
     Utils.showSnackBar(context, message: message);
   }
 

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -1218,7 +1218,9 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
   // When closing the meeting programmatically
   void closeMeetingProgrammatically(BuildContext context) {
     _isProgrammaticPop = true; // Set the flag
-    Navigator.popUntil(context, (route) => route.isFirst); // Close all routes
+    if (Navigator.canPop(context)) {
+      Navigator.of(context).pop();
+    }
   }
 
   void _meetingEndLogic(RtcViewmodel? viewModel) {

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -252,6 +252,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     })
     ..on<RoomDisconnectedEvent>((event) async {
       if (event.reason != null) {
+        _isProgrammaticPop = true;
         DatadogDisconnectLogger.logDisconnectEvent(
             meetingId: widget.meetingDetails.meetingUid,
             room: widget.room,


### PR DESCRIPTION
## 🚀 PR Summary

This PR focuses on enabling **direct meeting entry by skipping the pre-join screen**, making the SDK suitable for **instant video call use cases** (similar to 1:1 or quick join calls).

---

## ✨ Changes

- **feat:** Added `skipPreJoinPage` in `DaakiaMeetingConfiguration`  
  - Enables **bypassing pre-join UI**  
  - Supports **instant video call experience** with a loader screen  

- **feat:** Implemented `_startAutoJoinIfRequired` in `PreJoinScreen`  
  - Automatically joins meeting when skip is enabled  
  - Includes validation for restricted scenarios  

- **fix:** Improved navigation handling between PreJoin and Room screens  
- **fix:** Set programmatic pop flag on room disconnect to prevent unwanted back navigation  

- **chore:** Deprecated `getRecordingDispatchedId` API  

- **docs/example:** Updated example app and bumped version to `1.0.2+2`

---

## 🎯 Impact

- Enables **video call–like experience (no waiting screen)**  
- Reduces friction for quick joins and 1:1 calls  
- Improves navigation stability 