### PR TITLE
Feat/workshop mode

### DIFF
--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -10,6 +10,7 @@ import 'package:daakia_vc_flutter_sdk/model/screen_share_consent_model.dart';
 import 'package:daakia_vc_flutter_sdk/model/session_details_data.dart';
 import 'package:daakia_vc_flutter_sdk/model/translation_data.dart';
 import 'package:daakia_vc_flutter_sdk/model/webinar_permission_model.dart';
+import 'package:daakia_vc_flutter_sdk/model/workshop_permission_model.dart';
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 
@@ -148,7 +149,7 @@ abstract class RestClient {
 
   @POST("rtc/meeting/dispatch/agent")
   Future<BaseResponse<AgentDispatchData>> dispatchAgent(
-      @Body() Map<String, dynamic> body,
+    @Body() Map<String, dynamic> body,
   );
 
   @POST("rtc/meeting/text/translation")
@@ -255,6 +256,20 @@ abstract class RestClient {
 
   @PUT("rtc/videoPermission")
   Future<BaseResponse<WebinarPermissionModel>> updateVideoPermission(
+    @Header("Authorization") String token,
+    @Header("x-self-identity") String selfIdentity,
+    @Body() Map<String, dynamic> body,
+  );
+
+  @PUT("meeting/update/participantMicPermission")
+  Future<BaseResponse<WorkshopPermissionModel>> updateWorkshopMicPermission(
+    @Header("Authorization") String token,
+    @Header("x-self-identity") String selfIdentity,
+    @Body() Map<String, dynamic> body,
+  );
+
+  @PUT("meeting/update/participantVideoPermission")
+  Future<BaseResponse<WorkshopPermissionModel>> updateWorkshopVideoPermission(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,

--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -261,14 +261,14 @@ abstract class RestClient {
     @Body() Map<String, dynamic> body,
   );
 
-  @PUT("meeting/update/participantMicPermission")
+  @PUT("rtc/meeting/update/participantMicPermission")
   Future<BaseResponse<WorkshopPermissionModel>> updateWorkshopMicPermission(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @PUT("meeting/update/participantVideoPermission")
+  @PUT("rtc/meeting/update/participantVideoPermission")
   Future<BaseResponse<WorkshopPermissionModel>> updateWorkshopVideoPermission(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,

--- a/lib/api/api_client.g.dart
+++ b/lib/api/api_client.g.dart
@@ -1354,6 +1354,86 @@ class _RestClient implements RestClient {
     return _value;
   }
 
+  @override
+  Future<BaseResponse<WorkshopPermissionModel>> updateWorkshopMicPermission(
+    String token,
+    String selfIdentity,
+    Map<String, dynamic> body,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{
+      r'Authorization': token,
+      r'x-self-identity': selfIdentity,
+    };
+    _headers.removeWhere((k, v) => v == null);
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
+    final _options = _setStreamType<BaseResponse<WorkshopPermissionModel>>(
+      Options(method: 'PUT', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            'meeting/update/participantMicPermission',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseResponse<WorkshopPermissionModel> _value;
+    try {
+      _value = BaseResponse<WorkshopPermissionModel>.fromJson(
+        _result.data!,
+        (json) =>
+            WorkshopPermissionModel.fromJson(json as Map<String, dynamic>),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<BaseResponse<WorkshopPermissionModel>> updateWorkshopVideoPermission(
+    String token,
+    String selfIdentity,
+    Map<String, dynamic> body,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{
+      r'Authorization': token,
+      r'x-self-identity': selfIdentity,
+    };
+    _headers.removeWhere((k, v) => v == null);
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
+    final _options = _setStreamType<BaseResponse<WorkshopPermissionModel>>(
+      Options(method: 'PUT', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            'meeting/update/participantVideoPermission',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseResponse<WorkshopPermissionModel> _value;
+    try {
+      _value = BaseResponse<WorkshopPermissionModel>.fromJson(
+        _result.data!,
+        (json) =>
+            WorkshopPermissionModel.fromJson(json as Map<String, dynamic>),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/api/api_client.g.dart
+++ b/lib/api/api_client.g.dart
@@ -1373,7 +1373,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'meeting/update/participantMicPermission',
+            'rtc/meeting/update/participantMicPermission',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1413,7 +1413,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'meeting/update/participantVideoPermission',
+            'rtc/meeting/update/participantVideoPermission',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/model/workshop_permission_model.dart
+++ b/lib/model/workshop_permission_model.dart
@@ -8,14 +8,14 @@ class WorkshopPermissionModel {
   factory WorkshopPermissionModel.fromJson(Map<String, dynamic> json) {
     return WorkshopPermissionModel(
       isUpdated: json['updated'] as bool?,
-      videoPermission: json['video_permission'] as bool?,
+      videoPermission: json['is_video_enabled'] as bool?,
       audioPermission: json['is_mic_enabled'] as bool?,
     );
   }
 
   Map<String, dynamic> toJson() => {
-    if (isUpdated != null) 'video_permission': isUpdated,
-    if (videoPermission != null) 'updated': videoPermission,
+    if (isUpdated != null) 'updated': isUpdated,
+    if (videoPermission != null) 'is_video_enabled': videoPermission,
     if (audioPermission != null) 'is_mic_enabled': audioPermission,
   };
 }

--- a/lib/model/workshop_permission_model.dart
+++ b/lib/model/workshop_permission_model.dart
@@ -1,0 +1,21 @@
+class WorkshopPermissionModel {
+  bool? isUpdated;
+  bool? videoPermission;
+  bool? audioPermission;
+
+  WorkshopPermissionModel({this.isUpdated, this.videoPermission, this.audioPermission});
+
+  factory WorkshopPermissionModel.fromJson(Map<String, dynamic> json) {
+    return WorkshopPermissionModel(
+      isUpdated: json['updated'] as bool?,
+      videoPermission: json['video_permission'] as bool?,
+      audioPermission: json['is_mic_enabled'] as bool?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    if (isUpdated != null) 'video_permission': isUpdated,
+    if (videoPermission != null) 'updated': videoPermission,
+    if (audioPermission != null) 'is_mic_enabled': audioPermission,
+  };
+}

--- a/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
@@ -103,7 +103,7 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
               buildOption(context,
                   icon: Icons.security, // Replace with your host control icon
                   text: 'Host Control',
-                  isVisible: viewModel.isHost(), onTap: () {
+                  isVisible: viewModel.isHost() || viewModel.isCoHost(), onTap: () {
                 Navigator.pop(context);
                 showWebinarControls();
               }),

--- a/lib/presentation/dialog/pariticipant_dialog_controls.dart
+++ b/lib/presentation/dialog/pariticipant_dialog_controls.dart
@@ -61,7 +61,7 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
                               : MeetingActions.askToUnmuteMic),
                       widget.participant.identity);
                 },
-                isVisible: (widget.isForIndividual &&
+                isVisible: (widget.isForIndividual && (!widget.viewModel.isWebinarModeEnable) &&
                     (Utils.isHost(myRoleMataData) ||
                         Utils.isCoHost(myRoleMataData))),
               ),
@@ -78,7 +78,31 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
                               : MeetingActions.askToUnmuteCamera),
                       widget.participant.identity);
                 },
-                isVisible: (widget.isForIndividual &&
+                isVisible: (widget.isForIndividual && (!widget.viewModel.isWebinarModeEnable) &&
+                    (Utils.isHost(myRoleMataData) ||
+                        Utils.isCoHost(myRoleMataData))),
+              ),
+              CustomTextItem(
+                text: !Utils.isMicEnabled(widget.participant.attributes)
+                    ? "Allow Mic Permission"
+                    : "Revoke Mic Permission",
+                onTap: () {
+                  Navigator.pop(context);
+                  widget.viewModel.updateAudioPermissionForParticipant(widget.participant.identity, !Utils.isMicEnabled(widget.participant.attributes));
+                },
+                isVisible: (widget.isForIndividual && widget.viewModel.isWebinarModeEnable &&
+                    (Utils.isHost(myRoleMataData) ||
+                        Utils.isCoHost(myRoleMataData))),
+              ),
+              CustomTextItem(
+                text: !Utils.isVideoEnabled(widget.participant.attributes)
+                    ? "Allow Video Permission"
+                    : "Revoke Video Permission",
+                onTap: () {
+                  Navigator.pop(context);
+                  widget.viewModel.updateVideoPermissionForParticipant(widget.participant.identity, !Utils.isVideoEnabled(widget.participant.attributes));
+                },
+                isVisible: (widget.isForIndividual && widget.viewModel.isWebinarModeEnable &&
                     (Utils.isHost(myRoleMataData) ||
                         Utils.isCoHost(myRoleMataData))),
               ),

--- a/lib/presentation/dialog/pariticipant_dialog_controls.dart
+++ b/lib/presentation/dialog/pariticipant_dialog_controls.dart
@@ -90,7 +90,8 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
                   Navigator.pop(context);
                   widget.viewModel.updateAudioPermissionForParticipant(widget.participant.identity, !Utils.isMicEnabled(widget.participant.attributes));
                 },
-                isVisible: (widget.isForIndividual && widget.viewModel.isWebinarModeEnable &&
+                isVisible: (widget.isForIndividual && widget.viewModel.isAudioModeEnable &&
+                    (!Utils.isHost(targetRoleMataData) && !Utils.isCoHost(targetRoleMataData)) &&
                     (Utils.isHost(myRoleMataData) ||
                         Utils.isCoHost(myRoleMataData))),
               ),
@@ -102,7 +103,8 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
                   Navigator.pop(context);
                   widget.viewModel.updateVideoPermissionForParticipant(widget.participant.identity, !Utils.isVideoEnabled(widget.participant.attributes));
                 },
-                isVisible: (widget.isForIndividual && widget.viewModel.isWebinarModeEnable &&
+                isVisible: (widget.isForIndividual && widget.viewModel.isVideoModeEnable &&
+                    (!Utils.isHost(targetRoleMataData) && !Utils.isCoHost(targetRoleMataData)) &&
                     (Utils.isHost(myRoleMataData) ||
                         Utils.isCoHost(myRoleMataData))),
               ),

--- a/lib/presentation/dialog/pariticipant_dialog_controls.dart
+++ b/lib/presentation/dialog/pariticipant_dialog_controls.dart
@@ -61,7 +61,7 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
                               : MeetingActions.askToUnmuteMic),
                       widget.participant.identity);
                 },
-                isVisible: (widget.isForIndividual && (!widget.viewModel.isWebinarModeEnable) &&
+                isVisible: (widget.isForIndividual && (!widget.viewModel.isWebinarModeEnable || (widget.viewModel.isWebinarModeEnable && widget.participant.isMicrophoneEnabled())) &&
                     (Utils.isHost(myRoleMataData) ||
                         Utils.isCoHost(myRoleMataData))),
               ),
@@ -78,7 +78,7 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
                               : MeetingActions.askToUnmuteCamera),
                       widget.participant.identity);
                 },
-                isVisible: (widget.isForIndividual && (!widget.viewModel.isWebinarModeEnable) &&
+                isVisible: (widget.isForIndividual && (!widget.viewModel.isWebinarModeEnable || (widget.viewModel.isWebinarModeEnable && widget.participant.isCameraEnabled())) &&
                     (Utils.isHost(myRoleMataData) ||
                         Utils.isCoHost(myRoleMataData))),
               ),

--- a/lib/presentation/pages/webinar_controls.dart
+++ b/lib/presentation/pages/webinar_controls.dart
@@ -50,7 +50,7 @@ class WebinarControls extends StatelessWidget {
 
               // Webinar Mode Switch
               HostControlSwitch(
-                title: 'Webinar mode',
+                title: 'Workshop mode',
                 subtitle:
                     'If turned ON, all participants except Hosts / CoHosts stay muted with their camera off.',
                 value: viewModel.isWebinarModeEnable,

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -716,6 +716,28 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         viewModel?.syncRaiseHand(remoteData.raisedHands);
         break;
 
+      case MeetingActions.allowMicPermission:
+        viewModel?.isMicPermissionGranted = true;
+        showSnackBar(message: "Your mic permission has been granted");
+        break;
+
+      case MeetingActions.revokeMicPermission:
+        viewModel?.isMicPermissionGranted = false;
+        viewModel?.disableAudio();
+        showSnackBar(message: "Your mic permission has been revoked");
+        break;
+
+      case MeetingActions.allowVideoPermission:
+        viewModel?.isVideoPermissionGranted = true;
+        showSnackBar(message: "Your video permission has been granted");
+        break;
+
+      case MeetingActions.revokeVideoPermission:
+        viewModel?.isVideoPermissionGranted = false;
+        viewModel?.disableVideo();
+        showSnackBar(message: "Your video permission has been revoked");
+        break;
+
       case "":
       // Handle empty action case if needed
         break;

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -29,6 +29,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_background/flutter_background.dart';
 import 'package:livekit_client/livekit_client.dart';
+import 'package:provider/provider.dart';
 import 'package:simple_pip_mode/simple_pip.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:webview_flutter/webview_flutter.dart';
@@ -557,15 +558,19 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         break;
 
       case MeetingActions.forceMuteAll:
-        viewModel?.isAudioPermissionEnable = !remoteData.value;
-        if (!(viewModel?.isAudioPermissionEnable ?? false)) {
+        final isAudioModeEnabled = remoteData.value == true;
+        viewModel?.isAudioModeEnable = isAudioModeEnabled;
+        viewModel?.isAudioPermissionEnable = !isAudioModeEnabled;
+        if (isAudioModeEnabled) {
           viewModel?.disableAudio();
         }
         break;
 
       case MeetingActions.forceVideoOffAll:
-        viewModel?.isVideoPermissionEnable = !remoteData.value;
-        if (!(viewModel?.isVideoPermissionEnable ?? false)) {
+        final isVideoModeEnabled = remoteData.value == true;
+        viewModel?.isVideoModeEnable = isVideoModeEnabled;
+        viewModel?.isVideoPermissionEnable = !isVideoModeEnabled;
+        if (isVideoModeEnabled) {
           viewModel?.disableVideo();
         }
         break;
@@ -1047,6 +1052,27 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
                                             ),
                                         ],
                                       ),
+                                      Consumer<RtcViewmodel>(
+                                        builder: (context, viewModel, _) {
+                                          if (!viewModel.isWebinarModeEnable) {
+                                            return const SizedBox.shrink();
+                                          }
+                                          return Positioned(
+                                            left: 0,
+                                            right: 0,
+                                            top: 10,
+                                            child: IgnorePointer(
+                                              child: Center(
+                                                child: _buildTopStatusIndicator(
+                                                  label: 'Workshop',
+                                                  indicatorColor:
+                                                      const Color(0xFF34C759),
+                                                ),
+                                              ),
+                                            ),
+                                          );
+                                        },
+                                      ),
                                       if (_livekitProviderKey.currentState
                                               ?.viewModel.isRecording ==
                                           true)
@@ -1137,6 +1163,51 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
           },
         ) ??
         false;
+  }
+
+  Widget _buildTopStatusIndicator({
+    required String label,
+    required Color indicatorColor,
+  }) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.55),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(
+          color: indicatorColor.withValues(alpha: 0.35),
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 10,
+            height: 10,
+            decoration: BoxDecoration(
+              color: indicatorColor,
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: indicatorColor.withValues(alpha: 0.7),
+                  blurRadius: 8,
+                  spreadRadius: 1,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   void showSnackBar(

--- a/lib/rtc/widgets/rtc_controls.dart
+++ b/lib/rtc/widgets/rtc_controls.dart
@@ -102,7 +102,7 @@ class _RtcControlState extends State<RtcControls> {
               final isHostOrCoHost = viewModel.isHost() ||
                   viewModel.isCoHost();
 
-              if (isHostOrCoHost || viewModel.isVideoPermissionEnable) {
+              if (isHostOrCoHost || viewModel.isVideoPermissionEnable || viewModel.isVideoPermissionGranted) {
                 participant.isCameraEnabled()
                     ? viewModel.disableVideo()
                     : viewModel.enableVideo();
@@ -121,7 +121,7 @@ class _RtcControlState extends State<RtcControls> {
               final isHostOrCoHost = viewModel.isHost() ||
                   viewModel.isCoHost();
 
-              if (isHostOrCoHost || viewModel.isAudioPermissionEnable) {
+              if (isHostOrCoHost || viewModel.isAudioPermissionEnable || viewModel.isMicPermissionGranted) {
                 participant.isMicrophoneEnabled()
                     ? viewModel.disableAudio()
                     : viewModel.enableAudio();

--- a/lib/utils/meeting_actions.dart
+++ b/lib/utils/meeting_actions.dart
@@ -93,6 +93,10 @@ class MeetingActions {
 
   static const String responseRaisedHands = "response_raised_hands";
 
+  static const String allowMicPermission = "allow-mic-permission";
+
+  static const String allowVideoPermission = "allow-video-permission";
+
   // ✅ Add new fields here
 
   // ✅ Method to check if an action is valid
@@ -155,6 +159,8 @@ class MeetingActions {
     sendPrivateChat,
     requestRaisedHands,
     responseRaisedHands,
+    allowMicPermission,
+    allowVideoPermission,
     // ✅ Add new fields here
   };
 }

--- a/lib/utils/meeting_actions.dart
+++ b/lib/utils/meeting_actions.dart
@@ -165,6 +165,8 @@ class MeetingActions {
     responseRaisedHands,
     allowMicPermission,
     allowVideoPermission,
+    revokeMicPermission,
+    revokeVideoPermission,
     // ✅ Add new fields here
   };
 }

--- a/lib/utils/meeting_actions.dart
+++ b/lib/utils/meeting_actions.dart
@@ -95,7 +95,11 @@ class MeetingActions {
 
   static const String allowMicPermission = "allow-mic-permission";
 
+  static const String revokeMicPermission = "revoke-mic-permission";
+
   static const String allowVideoPermission = "allow-video-permission";
+
+  static const String revokeVideoPermission = "revoke-video-permission";
 
   // ✅ Add new fields here
 

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -492,4 +492,37 @@ class Utils {
     return ReplyMessage(name: name ?? (chat.identity?.name ?? ""), message: chat.message ?? "", id: chat.id ?? "", identity: chat.userIdentity ?? "");
   }
 
+  static bool isMicEnabled(Map<String, dynamic>? attributes) {
+    final value = attributes?['is_mic_enabled'];
+    return _toBool(value);
+  }
+
+  static bool isVideoEnabled(Map<String, dynamic>? attributes) {
+    final value = attributes?['is_video_enabled'];
+    return _toBool(value);
+  }
+
+  static bool _toBool(dynamic value) {
+    if (value == null) return false;
+
+    if (value is bool) return value;
+
+    if (value is String) {
+      switch (value.toLowerCase()) {
+        case 'true':
+        case '1':
+        case 'yes':
+          return true;
+        default:
+          return false;
+      }
+    }
+
+    if (value is num) {
+      return value != 0;
+    }
+
+    return false;
+  }
+
 }

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -825,7 +825,7 @@ class RtcViewmodel extends ChangeNotifier {
 
   set isAudioModeEnable(bool value) {
     _isAudioModeEnable = value;
-    _isWebinarModeEnable = (_isAudioModeEnable && _isVideoModeEnable);
+    _isWebinarModeEnable = (_isAudioModeEnable || _isVideoModeEnable);
     notifyListeners();
   }
 
@@ -834,7 +834,7 @@ class RtcViewmodel extends ChangeNotifier {
 
   set isVideoModeEnable(bool value) {
     _isVideoModeEnable = value;
-    _isWebinarModeEnable = (_isAudioModeEnable && _isVideoModeEnable);
+    _isWebinarModeEnable = (_isAudioModeEnable || _isVideoModeEnable);
     notifyListeners();
   }
 

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2379,6 +2379,7 @@ class RtcViewmodel extends ChangeNotifier {
         onSuccess: (data) {
           isAudioModeEnable = (data?.audioPermission == true);
           isAudioPermissionEnable = !(data?.audioPermission == true);
+          isMicPermissionGranted = Utils.isMicEnabled(room.localParticipant?.attributes);
         },
         onError: (message) {
           sendMessageToUI(message);
@@ -2414,6 +2415,7 @@ class RtcViewmodel extends ChangeNotifier {
         onSuccess: (data) {
           isVideoModeEnable = (data?.videoPermission == true);
           isVideoPermissionEnable = !(data?.videoPermission == true);
+          isVideoPermissionGranted = Utils.isVideoEnabled(room.localParticipant?.attributes);
         },
         onError: (message) {
           sendMessageToUI(message);

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2395,6 +2395,50 @@ class RtcViewmodel extends ChangeNotifier {
     );
   }
 
+  void updateAudioPermissionForParticipant(String participantIdentity, bool value) {
+    Map<String, dynamic> body = {
+      "meeting_uid": meetingDetails.meetingUid,
+      "participant_identity": participantIdentity,
+      "is_mic_enabled": value,
+    };
+
+    networkRequestHandler(
+        apiCall: ()=> apiClient.updateWorkshopMicPermission(meetingDetails.authorizationToken, selfIdentity, body),
+        onSuccess: (data) {
+          if (data == null) return;
+          if (data.isUpdated == true) {
+            final isAllow = data.audioPermission == true;
+            sendPrivateAction(ActionModel(action: isAllow ? MeetingActions.allowMicPermission : MeetingActions.revokeMicPermission), participantIdentity);
+          }
+        },
+        onError: (message) {
+          sendMessageToUI(message);
+        }
+    );
+  }
+
+  void updateVideoPermissionForParticipant(String participantIdentity, bool value) {
+    Map<String, dynamic> body = {
+      "meeting_uid": meetingDetails.meetingUid,
+      "participant_identity": participantIdentity,
+      "is_video_enabled": value,
+    };
+
+    networkRequestHandler(
+        apiCall: ()=> apiClient.updateWorkshopVideoPermission(meetingDetails.authorizationToken, selfIdentity, body),
+        onSuccess: (data) {
+          if (data == null) return;
+          if (data.isUpdated == true) {
+            final isAllow = data.videoPermission == true;
+            sendPrivateAction(ActionModel(action: isAllow ? MeetingActions.allowVideoPermission : MeetingActions.revokeVideoPermission), participantIdentity);
+          }
+        },
+        onError: (message) {
+          sendMessageToUI(message);
+        }
+    );
+  }
+
   //===============================[Live Caption]===============================
 
   @Deprecated("Use handleCaptionTranscription() instead")

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -419,12 +419,18 @@ class RtcViewmodel extends ChangeNotifier {
 
   double getMicAlpha() {
     if (isHost() || isCoHost()) return 1.0;
-    return isAudioPermissionEnable ? 1.0 : 0.5;
+    if (!isAudioPermissionEnable) {
+      return isMicPermissionGranted ? 1.0 : 0.5;
+    }
+    return 1.0;
   }
 
   double getCameraAlpha() {
     if (isHost() || isCoHost()) return 1.0;
-    return isVideoPermissionEnable ? 1.0 : 0.5;
+    if (!isVideoPermissionEnable) {
+      return isVideoPermissionGranted ? 1.0 : 0.5;
+    }
+    return 1.0;
   }
 
   bool isVisibleForHost(String role, String targetRole) {
@@ -2324,6 +2330,48 @@ class RtcViewmodel extends ChangeNotifier {
   }
 
   //===============================[Webinar Control]===============================
+
+  /// Controls microphone permission state for the **local participant**.
+  ///
+  /// This is specifically used in **Workshop Mode**, where each participant's
+  /// media permissions (mic/video) are managed independently rather than globally.
+  ///
+  /// Even if system-level permission is granted, this flag can be used to
+  /// logically enable/disable mic access within the app UI or business logic.
+  bool _isMicPermissionGranted = false;
+
+  /// Returns whether the microphone is allowed for the **local participant**
+  /// in Workshop Mode.
+  bool get isMicPermissionGranted => _isMicPermissionGranted;
+
+  /// Updates microphone permission state for the local participant
+  /// and notifies listeners to refresh the UI accordingly.
+  ///
+  /// Note: This does not request OS-level permission. It only controls
+  /// app-level behavior.
+  set isMicPermissionGranted(bool value) {
+    _isMicPermissionGranted = value;
+    notifyListeners();
+  }
+
+  /// Controls camera permission state for the **local participant**.
+  ///
+  /// Used in **Workshop Mode** to handle participant-level video control.
+  /// This allows enabling/disabling video independent of system permissions.
+  bool _isVideoPermissionGranted = false;
+
+  /// Returns whether the camera is allowed for the **local participant**
+  /// in Workshop Mode.
+  bool get isVideoPermissionGranted => _isVideoPermissionGranted;
+
+  /// Updates camera permission state for the local participant
+  /// and notifies listeners to update UI.
+  ///
+  /// Note: This is an app-level control, not a system permission request.
+  set isVideoPermissionGranted(bool value) {
+    _isVideoPermissionGranted = value;
+    notifyListeners();
+  }
 
   void getAudioPermission() {
     networkRequestHandler(


### PR DESCRIPTION
## PR: Workshop Permissions & Media Control Enhancements

### Changes
- Implemented `WorkshopPermissionModel` with JSON support
- Added APIs for updating **mic & video permissions**
- Introduced allow/revoke actions for media permissions
- Added utility methods to parse mic/video status
- Implemented **participant-level media permission control** (mic/camera)
- Updated RTC logic for permission handling & UI state sync
- Added Workshop mode media controls & status indicator
- Improved visibility logic for host/co-host controls
- Restricted permission controls for non host/co-host targets
- Renamed Webinar mode → Workshop mode & updated activation logic

### Notes
- Test mic/video permission grant & revoke flows
- Verify Workshop mode UI + status indicator
- Validate host/co-host control visibility & restrictions