### PR TITLE
Fix/minor UI issue

### DIFF
--- a/lib/presentation/pages/transcription_screen.dart
+++ b/lib/presentation/pages/transcription_screen.dart
@@ -585,7 +585,7 @@ class _SmartScrollCard extends StatelessWidget {
               color: Colors.blue.withValues(alpha: 0.15),
               borderRadius: BorderRadius.circular(8),
             ),
-            child: const Icon(Icons.vertical_align_bottom,
+            child: const Icon(Icons.unfold_more,
                 color: Colors.blue, size: 22),
           ),
           const SizedBox(width: 12),

--- a/lib/presentation/pages/transcription_screen.dart
+++ b/lib/presentation/pages/transcription_screen.dart
@@ -42,8 +42,9 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> {
       shouldAnchor: () => !_isSmartScrollEnabled,
     );
     widget.viewModel.addListener(_onViewModelChanged);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _fetchLanguagesIfNeeded();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await _fetchLanguagesIfNeeded();
+      if (!mounted) return;
       // Hosts/co-hosts who haven't started transcription are dropped straight
       // into the language picker so they can kick things off.
       if (!widget.viewModel.isTranscriptionLanguageSelected &&
@@ -98,13 +99,29 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> {
   void _openLanguagePicker() {
     final sourceLangCode =
         widget.viewModel.transcriptionLanguageData?.sourceLang;
-    final sourceLanguage = sourceLangCode != null
+    LanguageModel? sourceLanguage = sourceLangCode != null
         ? widget.viewModel.languages.firstWhere(
             (l) => l.code == sourceLangCode,
             orElse: () =>
                 LanguageModel(code: sourceLangCode, language: sourceLangCode),
           )
         : null;
+
+    // When transcription hasn't started yet, pre-select English (India) as the
+    // default so the user sees a sensible starting point. Nothing is applied
+    // until the user taps Apply.
+    if (sourceLanguage == null && widget.viewModel.languages.isNotEmpty) {
+      final matches =
+          widget.viewModel.languages.where((l) => l.code == 'en-IN');
+      if (matches.isNotEmpty) sourceLanguage = matches.first;
+    }
+
+    LanguageModel? targetLanguage = widget.viewModel.translationLanguage;
+    if (targetLanguage == null && widget.viewModel.languages.isNotEmpty) {
+      final matches =
+          widget.viewModel.languages.where((l) => l.code == 'en-IN');
+      if (matches.isNotEmpty) targetLanguage = matches.first;
+    }
 
     final isTranslationAllowed =
         widget.viewModel.meetingDetails.features?.isVoiceTextTranslationAllowed() ==
@@ -117,7 +134,7 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> {
       builder: (_) => LanguageSelectionBottomSheet(
         languages: widget.viewModel.languages,
         initialSourceLanguage: sourceLanguage,
-        initialTargetLanguage: widget.viewModel.translationLanguage,
+        initialTargetLanguage: targetLanguage,
         isSourceLanguageLocked: widget.viewModel.isTranscriptionStarter ||
             widget.viewModel.hasUsedParticipantLanguage,
         isTranslationAllowed: isTranslationAllowed,

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -612,6 +612,9 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
 
       case MeetingActions.stopLiveCaption:
         viewModel?.resetTranscriptionLanguage();
+        Future.microtask(() {
+          showSnackBar(message: "Live captions stopped");
+        });
         break;
 
       case MeetingActions.liveCaption:
@@ -1267,19 +1270,28 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     );
   }
 
-  void showSnackBar(
-      {required String message, String? actionText, Function? actionCallBack}) {
-    scaffoldMessengerKey.currentState?.showSnackBar(SnackBar(
-      content: Text(message),
-      action: actionText != null
-          ? SnackBarAction(
-              label: actionText,
-              onPressed: () {
-                actionCallBack?.call();
-              },
-            )
-          : null,
-    ));
+  void showSnackBar({
+    required String message,
+    String? actionText,
+    Function? actionCallBack,
+  }) {
+    final messenger = scaffoldMessengerKey.currentState;
+
+    messenger?.clearSnackBars(); // 👈 add this
+
+    messenger?.showSnackBar(
+      SnackBar(
+        content: Text(message),
+        action: actionText != null
+            ? SnackBarAction(
+          label: actionText,
+          onPressed: () {
+            actionCallBack?.call();
+          },
+        )
+            : null,
+      ),
+    );
   }
 
   bool isEventAdded = false;

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -842,7 +842,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         viewModel?.isMicPermissionGranted == true;
     DaakiaMeetingService.updateMuteState(
       isMuted: !micEnabled,
-      hasAudioPermission: hasAudioPerm,
+      hasAudioPermission: false, //TODO:: Temporary disable
     );
   }
 
@@ -1632,7 +1632,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         await DaakiaMeetingService.start(
           title: title,
           isMuted: !micEnabled,
-          hasAudioPermission: hasAudioPerm,
+          hasAudioPermission: false, //TODO:: Temporary disable
         );
       } else {
         // iOS: activate AVAudioSession so the app survives background even


### PR DESCRIPTION
## PR Summary

### Enhancements
- Added a snackbar notification when live captions are stopped.
- Improved snackbar handling by clearing existing snackbars before showing a new one to prevent queueing issues.
- Wrapped the "Live captions stopped" snackbar call inside a microtask for safer execution within the event loop.
- Updated the transcription screen icon from `Icons.vertical_align_bottom` to `Icons.unfold_more`.

### Transcription Improvements
- Awaited `_fetchLanguagesIfNeeded` during initialization.
- Added `mounted` checks to avoid state updates on unmounted widgets.
- Added default language pre-selection (`en-IN`) for both source and target languages when no previous selection exists.
- Improved language picker UX with sensible default selections.

### Temporary Changes
- Temporarily disabled mute/unmute functionality in `DaakiaMeetingService` by forcing `hasAudioPermission` to `false`.