### PR TITLE
Fix/background-service-issue

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application>
@@ -9,7 +10,7 @@
             android:name="io.daakia.daakia_vc_flutter_sdk.DaakiaMeetingService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="mediaPlayback" />
+            android:foregroundServiceType="mediaPlayback|mediaProjection" />
     </application>
 
 </manifest>

--- a/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaMeetingService.kt
+++ b/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaMeetingService.kt
@@ -29,15 +29,15 @@ class DaakiaMeetingService : Service() {
         const val EXTRA_TITLE = "title"
         const val EXTRA_TEXT = "text"
         const val EXTRA_IS_MUTED = "is_muted"
-        const val EXTRA_HAS_AUDIO_PERM = "has_audio_perm"
+        const val EXTRA_SHOW_MUTE_BTN = "show_mute_btn"
 
-        fun start(context: Context, title: String, text: String, isMuted: Boolean, hasAudioPerm: Boolean) {
+        fun start(context: Context, title: String, text: String, isMuted: Boolean, showMuteButton: Boolean) {
             val intent = Intent(context, DaakiaMeetingService::class.java).apply {
                 action = ACTION_START
                 putExtra(EXTRA_TITLE, title)
                 putExtra(EXTRA_TEXT, text)
                 putExtra(EXTRA_IS_MUTED, isMuted)
-                putExtra(EXTRA_HAS_AUDIO_PERM, hasAudioPerm)
+                putExtra(EXTRA_SHOW_MUTE_BTN, showMuteButton)
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 context.startForegroundService(intent)
@@ -46,11 +46,11 @@ class DaakiaMeetingService : Service() {
             }
         }
 
-        fun update(context: Context, isMuted: Boolean, hasAudioPerm: Boolean) {
+        fun update(context: Context, isMuted: Boolean, showMuteButton: Boolean) {
             val intent = Intent(context, DaakiaMeetingService::class.java).apply {
                 action = ACTION_UPDATE
                 putExtra(EXTRA_IS_MUTED, isMuted)
-                putExtra(EXTRA_HAS_AUDIO_PERM, hasAudioPerm)
+                putExtra(EXTRA_SHOW_MUTE_BTN, showMuteButton)
             }
             context.startService(intent)
         }
@@ -63,7 +63,7 @@ class DaakiaMeetingService : Service() {
     private var meetingTitle = "Meeting"
     private var meetingText = "Tap to return to the meeting"
     private var isMuted = false
-    private var hasAudioPerm = true
+    private var showMuteButton = false
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -73,12 +73,12 @@ class DaakiaMeetingService : Service() {
                 meetingTitle = intent.getStringExtra(EXTRA_TITLE) ?: meetingTitle
                 meetingText = intent.getStringExtra(EXTRA_TEXT) ?: meetingText
                 isMuted = intent.getBooleanExtra(EXTRA_IS_MUTED, isMuted)
-                hasAudioPerm = intent.getBooleanExtra(EXTRA_HAS_AUDIO_PERM, hasAudioPerm)
+                showMuteButton = intent.getBooleanExtra(EXTRA_SHOW_MUTE_BTN, showMuteButton)
                 startMeetingForeground()
             }
             ACTION_UPDATE -> {
                 isMuted = intent.getBooleanExtra(EXTRA_IS_MUTED, isMuted)
-                hasAudioPerm = intent.getBooleanExtra(EXTRA_HAS_AUDIO_PERM, hasAudioPerm)
+                showMuteButton = intent.getBooleanExtra(EXTRA_SHOW_MUTE_BTN, showMuteButton)
                 refreshNotification()
             }
             ACTION_TOGGLE_MUTE -> {
@@ -149,8 +149,7 @@ class DaakiaMeetingService : Service() {
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setCategory(NotificationCompat.CATEGORY_CALL)
 
-        // Mute / Unmute — only when mic permission is available
-        if (hasAudioPerm) {
+        if (showMuteButton) {
             val muteLabel = if (isMuted) "Unmute" else "Mute"
             val muteIcon = if (isMuted)
                 android.R.drawable.ic_lock_silent_mode_off

--- a/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaMeetingService.kt
+++ b/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaMeetingService.kt
@@ -31,6 +31,10 @@ class DaakiaMeetingService : Service() {
         const val EXTRA_IS_MUTED = "is_muted"
         const val EXTRA_SHOW_MUTE_BTN = "show_mute_btn"
 
+        // Held so the plugin can call startForeground() synchronously on the
+        // main thread without going through an intent round-trip.
+        var instance: DaakiaMeetingService? = null
+
         fun start(context: Context, title: String, text: String, isMuted: Boolean, showMuteButton: Boolean) {
             val intent = Intent(context, DaakiaMeetingService::class.java).apply {
                 action = ACTION_START
@@ -64,6 +68,51 @@ class DaakiaMeetingService : Service() {
     private var meetingText = "Tap to return to the meeting"
     private var isMuted = false
     private var showMuteButton = false
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+    }
+
+    override fun onDestroy() {
+        instance = null
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+        super.onDestroy()
+    }
+
+    /** Adds mediaProjection type to the running FGS. Must be called on the main thread,
+     *  immediately after the user grants screen capture permission. */
+    fun addMediaProjectionType() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            try {
+                ServiceCompat.startForeground(
+                    this,
+                    NOTIFICATION_ID,
+                    buildNotification(),
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK or
+                            ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
+                )
+            } catch (e: Exception) {
+                Log.w(TAG, "addMediaProjectionType failed: $e")
+            }
+        }
+    }
+
+    /** Removes mediaProjection type from the running FGS once screen share ends. */
+    fun removeMediaProjectionType() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            try {
+                ServiceCompat.startForeground(
+                    this,
+                    NOTIFICATION_ID,
+                    buildNotification(),
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                )
+            } catch (e: Exception) {
+                Log.w(TAG, "removeMediaProjectionType failed: $e")
+            }
+        }
+    }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -192,8 +241,4 @@ class DaakiaMeetingService : Service() {
         }
     }
 
-    override fun onDestroy() {
-        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
-        super.onDestroy()
-    }
 }

--- a/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaVcFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaVcFlutterSdkPlugin.kt
@@ -37,8 +37,8 @@ class DaakiaVcFlutterSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHandler 
                 val title = call.argument<String>("title") ?: "Meeting"
                 val text = call.argument<String>("text") ?: "Tap to return to the meeting"
                 val isMuted = call.argument<Boolean>("isMuted") ?: false
-                val hasAudioPerm = call.argument<Boolean>("hasAudioPerm") ?: true
-                DaakiaMeetingService.start(context, title, text, isMuted, hasAudioPerm)
+                val showMuteButton = call.argument<Boolean>("showMuteButton") ?: false
+                DaakiaMeetingService.start(context, title, text, isMuted, showMuteButton)
                 result.success(null)
             }
             "stopMeetingService" -> {
@@ -47,8 +47,8 @@ class DaakiaVcFlutterSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHandler 
             }
             "updateMuteState" -> {
                 val isMuted = call.argument<Boolean>("isMuted") ?: false
-                val hasAudioPerm = call.argument<Boolean>("hasAudioPerm") ?: true
-                DaakiaMeetingService.update(context, isMuted, hasAudioPerm)
+                val showMuteButton = call.argument<Boolean>("showMuteButton") ?: false
+                DaakiaMeetingService.update(context, isMuted, showMuteButton)
                 result.success(null)
             }
             else -> result.notImplemented()

--- a/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaVcFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaVcFlutterSdkPlugin.kt
@@ -45,6 +45,14 @@ class DaakiaVcFlutterSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHandler 
                 DaakiaMeetingService.stop(context)
                 result.success(null)
             }
+            "startScreenShareService" -> {
+                DaakiaMeetingService.instance?.addMediaProjectionType()
+                result.success(null)
+            }
+            "stopScreenShareService" -> {
+                DaakiaMeetingService.instance?.removeMediaProjectionType()
+                result.success(null)
+            }
             "updateMuteState" -> {
                 val isMuted = call.argument<Boolean>("isMuted") ?: false
                 val showMuteButton = call.argument<Boolean>("showMuteButton") ?: false

--- a/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
@@ -10,6 +10,7 @@ import 'package:livekit_client/livekit_client.dart';
 import 'package:provider/provider.dart';
 
 import '../../model/action_model.dart';
+import '../../service/daakia_meeting_service.dart';
 import '../../resources/colors/color.dart';
 import '../../utils/meeting_actions.dart';
 import '../../utils/utils.dart';
@@ -299,38 +300,44 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
         return;
       }
 
-      requestBackgroundPermission([bool isRetry = false]) async {
-        // Required for android screenshare.
-        try {
-          bool hasPermissions = await FlutterBackground.hasPermissions;
-          var appName = await Utils.getAppName();
-          if (!isRetry) {
-            var androidConfig = FlutterBackgroundAndroidConfig(
-              notificationTitle: 'Screen Sharing',
-              notificationText: '$appName is sharing the screen.',
-              notificationImportance: AndroidNotificationImportance.high,
-              // notificationIcon: const AndroidResource(
-              //     name: 'livekit_ic_launcher', defType: 'mipmap'),
-            );
-            hasPermissions = await FlutterBackground.initialize(
-                androidConfig: androidConfig);
-          }
-          if (hasPermissions &&
-              !FlutterBackground.isBackgroundExecutionEnabled) {
-            await FlutterBackground.enableBackgroundExecution();
-          }
-        } catch (e) {
-          if (!isRetry) {
-            return await Future<void>.delayed(const Duration(seconds: 1),
-                () => requestBackgroundPermission(true));
-          }
-          if (kDebugMode) {
-            print('could not publish video: $e');
+      final androidVersion = await Utils.getAndroidVersion();
+      if (androidVersion >= 34) {
+        // On Android 14+ use DaakiaMeetingService (already running for the
+        // meeting). Calling addMediaProjectionType() on the main thread is
+        // synchronous, so the FGS type is registered before getDisplayMedia
+        // is called — no race condition on rapid stop/start.
+        await DaakiaMeetingService.startScreenShare();
+      } else {
+        requestBackgroundPermission([bool isRetry = false]) async {
+          try {
+            bool hasPermissions = await FlutterBackground.hasPermissions;
+            var appName = await Utils.getAppName();
+            if (!isRetry) {
+              var androidConfig = FlutterBackgroundAndroidConfig(
+                notificationTitle: 'Screen Sharing',
+                notificationText: '$appName is sharing the screen.',
+                notificationImportance: AndroidNotificationImportance.high,
+              );
+              hasPermissions = await FlutterBackground.initialize(
+                  androidConfig: androidConfig);
+            }
+            if (hasPermissions &&
+                !FlutterBackground.isBackgroundExecutionEnabled) {
+              await FlutterBackground.enableBackgroundExecution();
+            }
+          } catch (e) {
+            if (!isRetry) {
+              return await Future<void>.delayed(const Duration(seconds: 1),
+                  () => requestBackgroundPermission(true));
+            }
+            if (kDebugMode) {
+              print('could not publish video: $e');
+            }
           }
         }
-      }
 
-      await requestBackgroundPermission();
+        await requestBackgroundPermission();
+      }
     }
 
     if (lkPlatformIs(PlatformType.iOS)) {
@@ -365,12 +372,16 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
     viewModel
         .sendAction(ActionModel(action: MeetingActions.screenShareStopped));
     if (lkPlatformIs(PlatformType.android)) {
-      // Android specific
-      try {
-        await FlutterBackground.disableBackgroundExecution();
-      } catch (error) {
-        if (kDebugMode) {
-          print('error disabling screen share: $error');
+      final androidVersion = await Utils.getAndroidVersion();
+      if (androidVersion >= 34) {
+        await DaakiaMeetingService.stopScreenShare();
+      } else {
+        try {
+          await FlutterBackground.disableBackgroundExecution();
+        } catch (error) {
+          if (kDebugMode) {
+            print('error disabling screen share: $error');
+          }
         }
       }
     }

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -774,7 +774,6 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
 
   RemoteActivityData parseJsonData(List<int> jsonData) {
     final jsonString = utf8.decode(jsonData); // Convert Uint8List to String
-    print("[DEBUG] - $jsonString");
     final Map<String, dynamic> jsonMap =
         json.decode(jsonString); // Decode the JSON string
     return RemoteActivityData.fromJson(

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -837,12 +837,8 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     final micEnabled = widget.room.localParticipant?.isMicrophoneEnabled() ?? false;
     if (micEnabled == _lastMicEnabled) return;
     _lastMicEnabled = micEnabled;
-    final viewModel = _livekitProviderKey.currentState?.viewModel;
-    final hasAudioPerm = viewModel?.isAudioPermissionEnable == true ||
-        viewModel?.isMicPermissionGranted == true;
     DaakiaMeetingService.updateMuteState(
       isMuted: !micEnabled,
-      hasAudioPermission: false, //TODO:: Temporary disable
     );
   }
 
@@ -1626,13 +1622,10 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     if (enable) {
       if (isAndroid) {
         final micEnabled = widget.room.localParticipant?.isMicrophoneEnabled() ?? false;
-        final viewModel = _livekitProviderKey.currentState?.viewModel;
-        final hasAudioPerm = viewModel?.isAudioPermissionEnable == true ||
-            viewModel?.isMicPermissionGranted == true;
         await DaakiaMeetingService.start(
           title: title,
           isMuted: !micEnabled,
-          hasAudioPermission: false, //TODO:: Temporary disable
+          showMuteButton: false,
         );
       } else {
         // iOS: activate AVAudioSession so the app survives background even

--- a/lib/service/daakia_meeting_service.dart
+++ b/lib/service/daakia_meeting_service.dart
@@ -10,6 +10,8 @@ class DaakiaMeetingService {
   // Cached params so restartIfActive() can replay the last start() call.
   static String? _title;
   static String? _text;
+  static bool _showMuteButton = false;
+  static bool _isMuted = false;
 
   // Callbacks wired up by RoomPage to handle Android notification button presses.
   static VoidCallback? onMuteToggle;
@@ -44,12 +46,14 @@ class DaakiaMeetingService {
     required String title,
     String text = 'Tap to return to the meeting',
     bool isMuted = false,
-    bool hasAudioPermission = true,
+    bool showMuteButton = false,
   }) async {
     if (!Platform.isAndroid && !Platform.isIOS) return;
 
     _title = title;
     _text = text;
+    _isMuted = isMuted;
+    _showMuteButton = showMuteButton;
 
     if (Platform.isAndroid) {
       // POST_NOTIFICATIONS is a runtime permission on Android 13+.
@@ -64,7 +68,7 @@ class DaakiaMeetingService {
         'title': title,
         'text': text,
         'isMuted': isMuted,
-        'hasAudioPerm': hasAudioPermission,
+        'showMuteButton': showMuteButton,
       });
     } catch (e) {
       debugPrint('DaakiaMeetingService start error: $e');
@@ -75,13 +79,15 @@ class DaakiaMeetingService {
   /// No-op on iOS (audio session stays active regardless of mute state).
   static Future<void> updateMuteState({
     required bool isMuted,
-    required bool hasAudioPermission,
+    bool? showMuteButton,
   }) async {
     if (!Platform.isAndroid || _title == null) return;
+    _isMuted = isMuted;
+    if (showMuteButton != null) _showMuteButton = showMuteButton;
     try {
       await _channel.invokeMethod('updateMuteState', {
         'isMuted': isMuted,
-        'hasAudioPerm': hasAudioPermission,
+        'showMuteButton': _showMuteButton,
       });
     } catch (e) {
       debugPrint('DaakiaMeetingService updateMuteState error: $e');
@@ -92,13 +98,20 @@ class DaakiaMeetingService {
   /// (e.g. user just granted POST_NOTIFICATIONS mid-meeting). No-op on iOS.
   static Future<void> restartIfActive() async {
     if (!Platform.isAndroid || _title == null) return;
-    await start(title: _title!, text: _text ?? 'Tap to return to the meeting');
+    await start(
+      title: _title!,
+      text: _text ?? 'Tap to return to the meeting',
+      isMuted: _isMuted,
+      showMuteButton: _showMuteButton,
+    );
   }
 
   static Future<void> stop() async {
     if (!Platform.isAndroid && !Platform.isIOS) return;
     _title = null;
     _text = null;
+    _isMuted = false;
+    _showMuteButton = false;
     onMuteToggle = null;
     onEndCall = null;
     try {

--- a/lib/service/daakia_meeting_service.dart
+++ b/lib/service/daakia_meeting_service.dart
@@ -106,6 +106,29 @@ class DaakiaMeetingService {
     );
   }
 
+  /// Upgrades the running FGS to include mediaProjection type so that
+  /// flutter_webrtc can call getDisplayMedia. Must be called after the user
+  /// grants screen capture permission and before setScreenShareEnabled(true).
+  /// No-op on iOS and Android < 14 (flutter_background handles it there).
+  static Future<void> startScreenShare() async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _channel.invokeMethod('startScreenShareService');
+    } catch (e) {
+      debugPrint('DaakiaMeetingService startScreenShare error: $e');
+    }
+  }
+
+  /// Removes the mediaProjection type from the FGS after screen share ends.
+  static Future<void> stopScreenShare() async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _channel.invokeMethod('stopScreenShareService');
+    } catch (e) {
+      debugPrint('DaakiaMeetingService stopScreenShare error: $e');
+    }
+  }
+
   static Future<void> stop() async {
     if (!Platform.isAndroid && !Platform.isIOS) return;
     _title = null;


### PR DESCRIPTION
## PR Summary

### Foreground Service & Mute Control Improvements
- Replaced `hasAudioPerm` with a dedicated `showMuteButton` flag in `DaakiaMeetingService` and Android method channel communication.
- Updated notification actions to conditionally display mute/unmute controls based on `showMuteButton`.
- Cached `isMuted` and `showMuteButton` states in Flutter to support `restartIfActive`.
- Simplified mute state handling by removing audio permission checks and unused `viewModel` references.
- Defaulted `showMuteButton` to `false` with optional updates through `updateMuteState`.

### Android Screen Sharing Support
- Added dynamic foreground service type management for screen sharing on Android.
- Implemented `addMediaProjectionType` and `removeMediaProjectionType` in `DaakiaMeetingService`.
- Added plugin handlers for:
  - `startScreenShareService`
  - `stopScreenShareService`
- Introduced `startScreenShare` and `stopScreenShare` APIs in the Flutter layer.

### Android 14+ Compatibility
- Added support for Android 14+ media projection foreground service requirements.
- Implemented version-specific screen sharing handling:
  - Android 14+ uses media projection foreground services.
  - Older Android versions continue using legacy `FlutterBackground` handling.
- Updated screen share toggle logic in `more_option_bottomsheet.dart` based on Android version detection.

### Permissions & Service Configuration
- Added `FOREGROUND_SERVICE_MEDIA_PROJECTION` permission to `AndroidManifest.xml`.
- Updated foreground service configuration to include `mediaProjection`.

### Cleanup
- Removed unnecessary statements and obsolete permission-related logic.