### PR TITLE
Doc/v4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # CHANGELOG
 
+## v4.4.1 – (2026-05)
+
+### 🐞 Bug Fixes
+- **Android 16 (targetSDK=36) Screen Share Crash**
+    - Fixed `SecurityException: Media projections require a foreground service of type ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION` on Android 16.
+    - Resolved race condition when rapidly stopping and restarting screen share on any Android version.
+    - Implemented synchronous foreground service type management via `DaakiaMeetingService`.
+
+- **Meeting Notifications & Background Service**
+    - Refactored Android meeting notification handling from `flutter_background` to native `DaakiaMeetingService`.
+    - Fixed notification lifecycle and foreground service type management on Android.
+    - Improved meeting service stability across Android versions (10+).
+
+- **Live Captions/Transcription**
+    - Fixed transcription screen lifecycle and language selection state management.
+    - Added snackbar notification when live captions are stopped.
+    - Improved language selection defaults and persistence.
+
+### 🎨 Improvements
+
+- **Screen Sharing (Android)**
+    - Replaced async `flutter_background` calls with synchronous `DaakiaMeetingService.startScreenShare()` / `stopScreenShare()`.
+    - No more race conditions on rapid screen share toggling.
+    - Cleaner separation of foreground service concerns (mediaPlayback vs mediaProjection).
+
+- **iOS Meeting Service**
+    - Added native `DaakiaMeetingService` with AVAudioSession management for iOS.
+    - Improved background audio handling during meetings.
+    - Better lifecycle management for audio playback on iOS.
+
+### 📱 Platform-Specific
+- **Android**: Added `FOREGROUND_SERVICE_MEDIA_PROJECTION` permission and dynamic foreground service type upgrades.
+- **iOS**: Implemented `DaakiaMeetingService` with proper AVAudioSession configuration for meeting audio continuity.
+
+---
+
 ## v4.4.0 – (2026-03)
 
 ### 🚀 New Features

--- a/README.md
+++ b/README.md
@@ -231,31 +231,37 @@ void main() async {
 
 ### Android
 
-On Android, you will have to use a
-[media projection foreground service](https://developer.android.com/develop/background-work/services/fg-service-types#media-projection).
+Screen sharing is supported on Android 10+. The SDK uses a 
+[media projection foreground service](https://developer.android.com/develop/background-work/services/fg-service-types#media-projection) for this functionality.
 
-In the app's AndroidManifest.xml file, declare the service with the appropriate types and permissions as following:
+**Required permissions** (automatically merged from SDK's manifest):
+- `FOREGROUND_SERVICE`
+- `FOREGROUND_SERVICE_MEDIA_PROJECTION` (required for screen capture)
+- `POST_NOTIFICATIONS` (for Android 13+)
+
+**⚠️ v4.4.1 Update**: For Android versions < 14, update your app's `AndroidManifest.xml` to declare the service with `mediaProjection` type only:
 
 ```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  <!-- Required permissions for screen share -->
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA"/>
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+  
   <application>
     ...
     <service
-            android:name="de.julianassmann.flutter_background.IsolateHolderService"
-            android:enabled="true"
-            android:exported="false"
-            android:foregroundServiceType="mediaProjection|microphone|camera" />
+        android:name="de.julianassmann.flutter_background.IsolateHolderService"
+        android:enabled="true"
+        android:exported="false"
+        android:foregroundServiceType="mediaProjection" />
   </application>
 </manifest>
 ```
+
+> **Note**: In v4.4.1, the `foregroundServiceType` was changed from `"mediaProjection|microphone|camera"` to only `"mediaProjection"` to fix Android 16 compatibility issues. Remove `FOREGROUND_SERVICE_CAMERA` and `FOREGROUND_SERVICE_MICROPHONE` permissions if they were previously declared.
+
 ### iOS
-On iOS, a broadcast extension is needed in order to capture screen content from other apps. See For iOS-specific setup, refer to the [setup guide](example/ios/README.md) for instructions.
+On iOS, screen sharing requires a broadcast extension to capture content from other apps. Refer to the [iOS setup guide](example/ios/README.md) for detailed instructions.
 ## Support
 
 For support, email contact@daakia.co.in.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This SDK provides a simple and efficient way to add video conferencing features 
 ## Supported Platforms
 ✅ **Android**  | ✅ **iOS**
 
+## Latest Release
+**v4.4.1** - See [CHANGELOG.md](CHANGELOG.md) for detailed release notes and what's new.
 
 # How to use
 
@@ -19,7 +21,7 @@ add ``daakia_vc_flutter_sdk:`` to your ``pubspec.yaml`` dependencies then run ``
 
 ```yaml
   dependencies:
-    daakia_vc_flutter_sdk: ^4.4.0
+    daakia_vc_flutter_sdk: ^4.4.1
 ```
 
 
@@ -29,22 +31,49 @@ We require a set of permissions that need to be declared in your AppManifest.xml
 
 ```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.your.package">
+  <!-- Camera & Audio -->
   <uses-feature android:name="android.hardware.camera" />
   <uses-feature android:name="android.hardware.camera.autofocus" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.RECORD_AUDIO" />
+  
+  <!-- Network -->
+  <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+  
+  <!-- Bluetooth -->
   <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
   <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+  
+  <!-- Foreground Service (Meeting Notifications & Screen Share) -->
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+  
+  <!-- Notifications (Android 13+) -->
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+  
+  <!-- Storage -->
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
   ...
 </manifest>
 ```
+
+### ℹ️ Permission Details
+
+- **Foreground Service Permissions** (new in v4.4.1):
+  - `FOREGROUND_SERVICE`: Required for background meeting notifications
+  - `FOREGROUND_SERVICE_MEDIA_PLAYBACK`: For meeting audio when app is backgrounded
+  - `FOREGROUND_SERVICE_MEDIA_PROJECTION`: **Required for screen sharing on Android 10+**
+  
+- **POST_NOTIFICATIONS**: Required for meeting notifications on Android 13+
+
+These permissions are **automatically merged** from the SDK's manifest. You don't need to manually add them unless your app targets Android versions that require explicit declaration.
 
 ## 🪟 Picture-in-Picture (PiP) Support (Android Only)
 


### PR DESCRIPTION
## Documentation Updates

### Release Documentation
- Updated `CHANGELOG.md` for the `v4.4.1` release.
- Updated `README.md` with `v4.4.1` release changes and improved Android permission documentation.

### Android Screen Sharing Docs
- Expanded Android screen sharing setup instructions.
- Added updated guidance for Android foreground service and media projection permissions.
- Improved documentation for Android 14+ screen sharing support and configuration.