### PR TITLE
Fix/minor-fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ _build
 
 # AI
 CLAUDE.md
+graphify-out

--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -383,6 +383,7 @@ class _PreJoinState extends State<PreJoinScreen> {
       body["custom_metadata"] = widget.configuration?.metadata;
     }
     final cacheData = StorageHelper();
+    var isRejoiningAsCoHost = false;
     if (await cacheData.getMeetingUid() == widget.meetingId) {
       if (await cacheData.getSessionUid() ==
           widget.basicMeetingDetails?.currentSessionUid) {
@@ -390,12 +391,18 @@ class _PreJoinState extends State<PreJoinScreen> {
           body["meeting_attendance_uid"] = await cacheData.getAttendanceId();
           if (hostToken.isEmpty) {
             hostToken = await cacheData.getHostToken() ?? "";
+            isRejoiningAsCoHost =
+                await cacheData.getAttendanceRole() == AttendanceRole.cohost;
           }
         }
       }
     }
 
-    final token = hostToken;
+    // Co-host rejoining: let the server determine the role from meeting_attendance_uid.
+    // The cached host token is kept in hostToken for in-session API calls but must
+    // not be sent as the join Authorization header — doing so causes the server to
+    // grant host-level access instead of co-host.
+    final token = isRejoiningAsCoHost ? "" : hostToken;
 
     networkRequestHandlerWithMessage(
       apiCall: () => apiClient.getMeetingJoinDetail(token, body),

--- a/lib/presentation/widgets/file_preview.dart
+++ b/lib/presentation/widgets/file_preview.dart
@@ -9,7 +9,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_chat_types/flutter_chat_types.dart' show PreviewData;
 import 'package:flutter_link_previewer/flutter_link_previewer.dart';
-import 'package:mime/mime.dart';
 import 'package:open_file/open_file.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -36,7 +35,7 @@ class _FilePreviewWidgetState extends State<FilePreviewWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final mimeType = lookupMimeType(widget.fileUrl);
+    final mimeType = Utils.resolveMimeType(widget.fileUrl);
     final fileExtension = widget.fileUrl.split('.').last;
 
     TextStyle getTextStyle(Color textColor) {

--- a/lib/presentation/widgets/raised_hand_participant_widget.dart
+++ b/lib/presentation/widgets/raised_hand_participant_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../model/action_model.dart';
+import '../../model/raised_hand.dart';
 import '../../resources/colors/color.dart';
 import '../../utils/meeting_actions.dart';
 import '../../utils/utils.dart';
@@ -25,12 +26,17 @@ class _RaisedHandParticipantWidgetState
   Widget build(BuildContext context) {
     final raisedQueue = widget.viewModel.raisedHandQueue;
 
-    final raisedParticipants = raisedQueue
-        .map((e) => widget.viewModel.getParticipantNameByIdentity(e.identity))
-        .whereType<String>()
+    // Only keep entries for participants still present in the room.
+    // getParticipantNameOrNull returns null for stale/ghost identities.
+    final raisedEntries = raisedQueue
+        .map((e) {
+          final name = widget.viewModel.getParticipantNameOrNull(e.identity);
+          return name != null ? (e, name) : null;
+        })
+        .whereType<(RaisedHand, String)>()
         .toList();
 
-    if (raisedParticipants.isEmpty) return const SizedBox.shrink();
+    if (raisedEntries.isEmpty) return const SizedBox.shrink();
 
     return Theme(
       data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
@@ -82,10 +88,10 @@ class _RaisedHandParticipantWidgetState
           ListView.builder(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
-            itemCount: raisedParticipants.length,
+            itemCount: raisedEntries.length,
             itemBuilder: (context, index) {
-              final name = raisedParticipants[index];
-              final identity = raisedQueue[index].identity;
+              final (entry, name) = raisedEntries[index];
+              final identity = entry.identity;
 
               return Container(
                 width: double.maxFinite,

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -216,10 +216,18 @@ class Utils {
     return text.replaceAll(_urlRegex, '').trim();
   }
 
+  // lookupMimeType works purely by extension but misses some JPEG variants.
+  static String? resolveMimeType(String url) {
+    final mime = lookupMimeType(url);
+    if (mime != null) return mime;
+    final ext = url.split('?').first.split('.').last.toLowerCase();
+    const extraMappings = {'jfif': 'image/jpeg'};
+    return extraMappings[ext];
+  }
+
   static bool isFileLink(String url) {
     if (!isUrl(url)) return false;
-    final mimeType = lookupMimeType(url);
-    return mimeType != null; // If MIME type exists → it's likely a file
+    return resolveMimeType(url) != null;
   }
 
   static bool isLink(String message) {

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -1503,7 +1503,7 @@ class RtcViewmodel extends ChangeNotifier {
   }
 
   void configAutoRecording() {
-    if (isHost()) {
+    if (isHost() || isCoHost()) {
       if (meetingDetails.meetingBasicDetails?.meetingConfig != null) {
         var meetingConfig = meetingDetails.meetingBasicDetails?.meetingConfig!;
         if (meetingConfig?.recordingForceStopped != 1 &&

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -1396,6 +1396,11 @@ class RtcViewmodel extends ChangeNotifier {
     return _identityToNameMap[identity] ?? "Unknown";
   }
 
+  String? getParticipantNameOrNull(String? identity) {
+    if (identity == null) return null;
+    return _identityToNameMap[identity];
+  }
+
   var _isRequestedForTranscription = false;
 
   void requestForTranscriptionState() {


### PR DESCRIPTION
## Summary

This PR includes improvements for co-host handling, file MIME type detection, raised-hand participant validation, and auto-recording configuration support.

## Changes

- Allowed co-hosts to configure auto-recording settings in `rtc_viewmodel.dart`.
- Fixed co-host rejoin authorization.
- Added `resolveMimeType` utility to improve file type detection, including `.jfif` support.
- Updated file preview handling to use the centralized MIME type resolver.
- Added `getParticipantNameOrNull` in `RtcViewModel` to validate participant availability.
- Filtered stale/ghost participants from the raised-hand queue.
- Refactored `RaisedHandParticipantWidget` to use tuple-based participant mapping for consistent indexing.