### PR TITLE
Feat/hide participant page

### DIFF
--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -10,6 +10,7 @@ import 'package:daakia_vc_flutter_sdk/model/screen_share_consent_model.dart';
 import 'package:daakia_vc_flutter_sdk/model/session_details_data.dart';
 import 'package:daakia_vc_flutter_sdk/model/translation_data.dart';
 import 'package:daakia_vc_flutter_sdk/model/webinar_permission_model.dart';
+import 'package:daakia_vc_flutter_sdk/model/participant_drawer_consent_model.dart';
 import 'package:daakia_vc_flutter_sdk/model/workshop_permission_model.dart';
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
@@ -286,6 +287,19 @@ abstract class RestClient {
 
   @PUT("rtc/meeting/update/participantVideoPermission")
   Future<BaseResponse<WorkshopPermissionModel>> updateWorkshopVideoPermission(
+    @Header("Authorization") String token,
+    @Header("x-self-identity") String selfIdentity,
+    @Body() Map<String, dynamic> body,
+  );
+
+  @GET("rtc/meeting/get/participantDrawer")
+  Future<BaseResponse<ParticipantDrawerConsentModel>> getParticipantDrawerConsent(
+    @Header("x-self-identity") String selfIdentity,
+    @Query("meeting_uid") String meetingUid,
+  );
+
+  @PUT("rtc/meeting/allow/participantDrawer")
+  Future<BaseResponse<ParticipantDrawerConsentModel>> updateParticipantDrawerConsent(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,

--- a/lib/api/api_client.g.dart
+++ b/lib/api/api_client.g.dart
@@ -8,7 +8,7 @@ part of 'api_client.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main,avoid_redundant_argument_values
 
 class _RestClient implements RestClient {
   _RestClient(this._dio, {this.baseUrl, this.errorLogger});
@@ -48,7 +48,7 @@ class _RestClient implements RestClient {
         (json) => RtcData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -81,7 +81,7 @@ class _RestClient implements RestClient {
         (json) => HostTokenModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -111,7 +111,7 @@ class _RestClient implements RestClient {
         (json) => HostTokenModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -141,7 +141,7 @@ class _RestClient implements RestClient {
         (json) => FeatureData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -175,7 +175,7 @@ class _RestClient implements RestClient {
             EventPasswordProtectedData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -209,7 +209,7 @@ class _RestClient implements RestClient {
             EventPasswordProtectedData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -242,7 +242,7 @@ class _RestClient implements RestClient {
         (json) => RtcData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -275,7 +275,7 @@ class _RestClient implements RestClient {
         (json) => LicenceVerifyModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -309,7 +309,7 @@ class _RestClient implements RestClient {
         (json) => MeetingDetailsModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -344,7 +344,7 @@ class _RestClient implements RestClient {
         (json) => json as dynamic,
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -383,7 +383,7 @@ class _RestClient implements RestClient {
         (json) => json as dynamic,
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -422,7 +422,7 @@ class _RestClient implements RestClient {
         (json) => json as dynamic,
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -461,7 +461,7 @@ class _RestClient implements RestClient {
         (json) => EgressData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -500,7 +500,7 @@ class _RestClient implements RestClient {
         (json) => json as dynamic,
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -538,7 +538,7 @@ class _RestClient implements RestClient {
         (json) => RecordingDispatchData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -573,7 +573,7 @@ class _RestClient implements RestClient {
         (json) => RtcData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -600,11 +600,11 @@ class _RestClient implements RestClient {
     );
     final _options = _setStreamType<BaseResponse<UploadData>>(
       Options(
-        method: 'POST',
-        headers: _headers,
-        extra: _extra,
-        contentType: 'multipart/form-data',
-      )
+            method: 'POST',
+            headers: _headers,
+            extra: _extra,
+            contentType: 'multipart/form-data',
+          )
           .compose(
             _dio.options,
             'rtc/meeting/chat/uploadAttachment',
@@ -622,7 +622,7 @@ class _RestClient implements RestClient {
         (json) => UploadData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -661,7 +661,7 @@ class _RestClient implements RestClient {
         (json) => json as dynamic,
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -700,7 +700,7 @@ class _RestClient implements RestClient {
         (json) => json as dynamic,
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -735,7 +735,7 @@ class _RestClient implements RestClient {
         (json) => json as dynamic,
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -774,7 +774,7 @@ class _RestClient implements RestClient {
         (json) => AgentDispatchData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -809,7 +809,7 @@ class _RestClient implements RestClient {
         (json) => TranslationData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -848,7 +848,7 @@ class _RestClient implements RestClient {
         (json) => json as dynamic,
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -883,7 +883,7 @@ class _RestClient implements RestClient {
         (json) => json as dynamic,
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -922,7 +922,7 @@ class _RestClient implements RestClient {
         (json) => json as dynamic,
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -956,7 +956,7 @@ class _RestClient implements RestClient {
         (json) => WhiteboardData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -964,8 +964,7 @@ class _RestClient implements RestClient {
 
   @override
   Future<BaseListResponse<ParticipantAttendanceData>>
-      getAttendanceListForParticipant(
-          String selfIdentity, String meetingId) async {
+  getAttendanceListForParticipant(String selfIdentity, String meetingId) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{r'meeting_uid': meetingId};
     final _headers = <String, dynamic>{r'x-self-identity': selfIdentity};
@@ -973,17 +972,17 @@ class _RestClient implements RestClient {
     const Map<String, dynamic>? _data = null;
     final _options =
         _setStreamType<BaseListResponse<ParticipantAttendanceData>>(
-      Options(method: 'GET', headers: _headers, extra: _extra)
-          .compose(
-            _dio.options,
-            'rtc/meeting/invitee/participantsList',
-            queryParameters: queryParameters,
-            data: _data,
-          )
-          .copyWith(
-            baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl),
-          ),
-    );
+          Options(method: 'GET', headers: _headers, extra: _extra)
+              .compose(
+                _dio.options,
+                'rtc/meeting/invitee/participantsList',
+                queryParameters: queryParameters,
+                data: _data,
+              )
+              .copyWith(
+                baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl),
+              ),
+        );
     final _result = await _dio.fetch<Map<String, dynamic>>(_options);
     late BaseListResponse<ParticipantAttendanceData> _value;
     try {
@@ -993,7 +992,7 @@ class _RestClient implements RestClient {
             ParticipantAttendanceData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1028,7 +1027,7 @@ class _RestClient implements RestClient {
         (json) => ConsentStatusData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1062,7 +1061,7 @@ class _RestClient implements RestClient {
         (json) => SessionDetailsData.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1097,7 +1096,7 @@ class _RestClient implements RestClient {
         (json) => json as dynamic,
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1136,7 +1135,7 @@ class _RestClient implements RestClient {
             RemoteParticipantConsent.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1171,7 +1170,7 @@ class _RestClient implements RestClient {
             ScreenShareConsentModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1211,7 +1210,7 @@ class _RestClient implements RestClient {
             ScreenShareConsentModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1246,7 +1245,7 @@ class _RestClient implements RestClient {
             ChatAttachmentConsentModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1286,7 +1285,7 @@ class _RestClient implements RestClient {
             ChatAttachmentConsentModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1320,7 +1319,7 @@ class _RestClient implements RestClient {
         (json) => WebinarPermissionModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1359,7 +1358,7 @@ class _RestClient implements RestClient {
         (json) => WebinarPermissionModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1393,7 +1392,7 @@ class _RestClient implements RestClient {
         (json) => WebinarPermissionModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1432,7 +1431,7 @@ class _RestClient implements RestClient {
         (json) => WebinarPermissionModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1472,7 +1471,7 @@ class _RestClient implements RestClient {
             WorkshopPermissionModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;
@@ -1512,7 +1511,89 @@ class _RestClient implements RestClient {
             WorkshopPermissionModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options);
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<BaseResponse<ParticipantDrawerConsentModel>>
+  getParticipantDrawerConsent(String selfIdentity, String meetingUid) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'meeting_uid': meetingUid};
+    final _headers = <String, dynamic>{r'x-self-identity': selfIdentity};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options =
+        _setStreamType<BaseResponse<ParticipantDrawerConsentModel>>(
+          Options(method: 'GET', headers: _headers, extra: _extra)
+              .compose(
+                _dio.options,
+                'rtc/meeting/get/participantDrawer',
+                queryParameters: queryParameters,
+                data: _data,
+              )
+              .copyWith(
+                baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl),
+              ),
+        );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseResponse<ParticipantDrawerConsentModel> _value;
+    try {
+      _value = BaseResponse<ParticipantDrawerConsentModel>.fromJson(
+        _result.data!,
+        (json) => ParticipantDrawerConsentModel.fromJson(
+          json as Map<String, dynamic>,
+        ),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<BaseResponse<ParticipantDrawerConsentModel>>
+  updateParticipantDrawerConsent(
+    String token,
+    String selfIdentity,
+    Map<String, dynamic> body,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{
+      r'Authorization': token,
+      r'x-self-identity': selfIdentity,
+    };
+    _headers.removeWhere((k, v) => v == null);
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
+    final _options =
+        _setStreamType<BaseResponse<ParticipantDrawerConsentModel>>(
+          Options(method: 'PUT', headers: _headers, extra: _extra)
+              .compose(
+                _dio.options,
+                'rtc/meeting/allow/participantDrawer',
+                queryParameters: queryParameters,
+                data: _data,
+              )
+              .copyWith(
+                baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl),
+              ),
+        );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseResponse<ParticipantDrawerConsentModel> _value;
+    try {
+      _value = BaseResponse<ParticipantDrawerConsentModel>.fromJson(
+        _result.data!,
+        (json) => ParticipantDrawerConsentModel.fromJson(
+          json as Map<String, dynamic>,
+        ),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
       rethrow;
     }
     return _value;

--- a/lib/model/participant_drawer_consent_model.dart
+++ b/lib/model/participant_drawer_consent_model.dart
@@ -1,0 +1,16 @@
+class ParticipantDrawerConsentModel {
+  bool isAllowed;
+
+  ParticipantDrawerConsentModel({required this.isAllowed});
+
+  factory ParticipantDrawerConsentModel.fromJson(Map<String, dynamic> json) {
+    final raw = json['is_allowed'];
+    return ParticipantDrawerConsentModel(
+      isAllowed: raw is bool ? raw : (raw as int? ?? 1) == 1,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'is_allowed': isAllowed,
+  };
+}

--- a/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
@@ -151,10 +151,11 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
               // Participants
               buildOption(
                 context,
-                icon: Icons.people, // Replace with your participants icon
+                icon: Icons.people,
                 text: 'Participants',
+                isVisible: viewModel.isHost() || viewModel.isCoHost() || !viewModel.isParticipantDrawerHidden,
                 onTap: () {
-                  showParticipantBottomSheet();
+                  showParticipantBottomSheet(viewModel);
                 },
               ),
               buildOption(context,
@@ -179,15 +180,18 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
     );
   }
 
-  void showParticipantBottomSheet() {
+  void showParticipantBottomSheet(RtcViewmodel viewModel) {
     if (Navigator.of(context).canPop()) {
       Navigator.of(context).pop(); // This will dismiss the BottomSheet
     }
+    viewModel.isParticipantPageOpen = true;
     Navigator.of(context).push(MaterialPageRoute<Null>(
         builder: (BuildContext context) {
           return const AllParticipantPage();
         },
-        fullscreenDialog: true));
+        fullscreenDialog: true)).then((_) {
+      viewModel.isParticipantPageOpen = false;
+    });
   }
 
   void showEmojiDialog(RtcViewmodel viewModel) {

--- a/lib/presentation/pages/webinar_controls.dart
+++ b/lib/presentation/pages/webinar_controls.dart
@@ -89,6 +89,20 @@ class WebinarControls extends StatelessWidget {
                 isDividerRequired: false,
               ),
 
+              // Hide Participant List Switch
+              HostControlSwitch(
+                title: 'Hide Participant list',
+                subtitle:
+                    'If turned on, participants cannot open the participant list.',
+                value: viewModel.isParticipantDrawerHidden,
+                onChanged: (value) {
+                  viewModel.isParticipantDrawerHidden = value;
+                  viewModel.updateParticipantDrawerConsent(value);
+                },
+                isChild: true,
+                isDividerRequired: false,
+              ),
+
               const Divider(color: Colors.white),
 
               // Chat Attachment Download

--- a/lib/presentation/pages/webinar_controls.dart
+++ b/lib/presentation/pages/webinar_controls.dart
@@ -58,6 +58,8 @@ class WebinarControls extends StatelessWidget {
                   viewModel.isWebinarModeEnable = value;
                   viewModel.updateAudioPermission(value);
                   viewModel.updateVideoPermission(value);
+                  viewModel.isParticipantDrawerHidden = value;
+                  viewModel.updateParticipantDrawerConsent(value);
                 },
                 isDividerRequired: false,
               ),

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -153,17 +153,25 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         viewModel?.fetchAndStoreSessionUid();
       }
 
-      if (viewModel?.meetingDetails.features?.isScreenShareRequestAllowed() == true) {
-        viewModel?.getScreenShareConsent();
-      }
-
-      if (viewModel?.meetingDetails.features?.isConferenceChatAttachmentAllowed() == true) {
-        viewModel?.getChatAttachmentConsent();
-      }
-
+      // Wave 1 – critical permissions needed before the UI is interactive
       viewModel?.getAudioPermission();
       viewModel?.getVideoPermission();
       viewModel?.getParticipantDrawerConsent();
+
+      // Wave 2 – secondary data, staggered to avoid flooding the server
+      Future.delayed(const Duration(milliseconds: 600), () {
+        if (!mounted) return;
+        var vm = _livekitProviderKey.currentState?.viewModel;
+        if (vm == null) return;
+
+        if (vm.meetingDetails.features?.isScreenShareRequestAllowed() == true) {
+          vm.getScreenShareConsent();
+        }
+
+        if (vm.meetingDetails.features?.isConferenceChatAttachmentAllowed() == true) {
+          vm.getChatAttachmentConsent();
+        }
+      });
 
       DaakiaPiP.createPipVideoCall(
           name: widget.room.localParticipant?.name ?? "Unknown",

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -109,9 +109,13 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         setState(() {
           _isInPipMode = false;
         });
-      })
-        ..setAutoPipMode(
-            aspectRatio: (1, 1), seamlessResize: true, autoEnter: true);
+      });
+      pip?.setAutoPipMode(
+          aspectRatio: (1, 1), seamlessResize: true, autoEnter: true)
+        .catchError((e) {
+          // setAutoPipMode requires Android S (API 31+); silently ignore on older versions
+          return false;
+        });
     }
     isCheckedWhileJoining = false;
     player = AudioPlayer();

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -163,6 +163,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
 
       viewModel?.getAudioPermission();
       viewModel?.getVideoPermission();
+      viewModel?.getParticipantDrawerConsent();
 
       DaakiaPiP.createPipVideoCall(
           name: widget.room.localParticipant?.name ?? "Unknown",
@@ -759,6 +760,14 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         showSnackBar(message: "Your video permission has been revoked");
         break;
 
+      case MeetingActions.hideParticipantDrawer:
+        final isHidden = remoteData.value == true;
+        viewModel?.isParticipantDrawerHidden = isHidden;
+        if (isHidden && viewModel?.isParticipantPageOpen == true) {
+          _innerNavigatorKey.currentState?.maybePop();
+        }
+        break;
+
       case "":
       // Handle empty action case if needed
         break;
@@ -952,6 +961,9 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
   final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey =
       GlobalKey<ScaffoldMessengerState>();
 
+  final GlobalKey<NavigatorState> _innerNavigatorKey =
+      GlobalKey<NavigatorState>();
+
   late final WebViewController _webViewController;
   bool _webViewInitialized = false;
 
@@ -1028,6 +1040,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         room: widget.room,
         meetingDetails: widget.meetingDetails,
         child: MaterialApp(
+          navigatorKey: _innerNavigatorKey,
           scaffoldMessengerKey: scaffoldMessengerKey,
           debugShowCheckedModeBanner: false,
           home: (_isInPipMode)

--- a/lib/utils/meeting_actions.dart
+++ b/lib/utils/meeting_actions.dart
@@ -102,6 +102,8 @@ class MeetingActions {
 
   static const String revokeVideoPermission = "revoke-video-permission";
 
+  static const String hideParticipantDrawer = "hide_participant_drawer";
+
   // ✅ Add new fields here
 
   // ✅ Method to check if an action is valid
@@ -169,6 +171,7 @@ class MeetingActions {
     revokeMicPermission,
     revokeVideoPermission,
     stopLiveCaption,
+    hideParticipantDrawer,
     // ✅ Add new fields here
   };
 }

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2559,6 +2559,51 @@ class RtcViewmodel extends ChangeNotifier {
     );
   }
 
+  //===============================[Participant Drawer]===============================
+
+  bool _isParticipantDrawerHidden = false;
+
+  bool get isParticipantDrawerHidden => _isParticipantDrawerHidden;
+
+  set isParticipantDrawerHidden(bool value) {
+    _isParticipantDrawerHidden = value;
+    notifyListeners();
+  }
+
+  bool isParticipantPageOpen = false;
+
+  void getParticipantDrawerConsent() {
+    networkRequestHandler(
+        apiCall: () => apiClient.getParticipantDrawerConsent(selfIdentity, meetingDetails.meetingUid),
+        onSuccess: (data) {
+          isParticipantDrawerHidden = !(data?.isAllowed ?? true);
+        },
+        onError: (message) {
+          sendMessageToUI(message);
+          isParticipantDrawerHidden = false;
+        }
+    );
+  }
+
+  void updateParticipantDrawerConsent(bool isHidden) {
+    Map<String, dynamic> body = {
+      "meeting_uid": meetingDetails.meetingUid,
+      "is_allowed": !isHidden,
+    };
+
+    networkRequestHandler(
+        apiCall: () => apiClient.updateParticipantDrawerConsent(meetingDetails.authorizationToken, selfIdentity, body),
+        onSuccess: (data) {
+          isParticipantDrawerHidden = !(data?.isAllowed ?? true);
+          sendAction(ActionModel(action: MeetingActions.hideParticipantDrawer, value: _isParticipantDrawerHidden));
+        },
+        onError: (message) {
+          sendMessageToUI(message);
+          isParticipantDrawerHidden = !isParticipantDrawerHidden;
+        }
+    );
+  }
+
   //===============================[Live Caption]===============================
 
   @Deprecated("Use handleCaptionTranscription() instead")


### PR DESCRIPTION
## Summary

This PR adds webinar participant drawer visibility controls, consent handling, and improves room initialization stability.

## Changes

- Added participant drawer consent model and related API endpoints.
- Added `hide_participant_drawer` meeting action support.
- Implemented webinar controls to hide/show the participant list.
- Updated webinar mode toggle flow to manage participant drawer visibility and consent handling.
- Refactored room initialization to stagger non-critical permission requests for smoother startup.
- Added error handling for `setAutoPipMode` on unsupported Android versions.