### PR TITLE
Fix/call state interruption

### DIFF
--- a/ios/Classes/DaakiaVcFlutterSdkPlugin.swift
+++ b/ios/Classes/DaakiaVcFlutterSdkPlugin.swift
@@ -3,24 +3,29 @@ import UIKit
 import AVFoundation
 
 public class DaakiaVcFlutterSdkPlugin: NSObject, FlutterPlugin {
+    private var channel: FlutterMethodChannel?
+    private var isInterrupted = false
 
     public static func register(with registrar: FlutterPluginRegistrar) {
-        let channel = FlutterMethodChannel(
+        let ch = FlutterMethodChannel(
             name: "io.daakia/meeting_service",
             binaryMessenger: registrar.messenger()
         )
         let instance = DaakiaVcFlutterSdkPlugin()
-        registrar.addMethodCallDelegate(instance, channel: channel)
+        instance.channel = ch
+        registrar.addMethodCallDelegate(instance, channel: ch)
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "startMeetingService":
             activateAudioSession()
+            registerInterruptionObserver()
             result(nil)
         case "stopMeetingService":
             // Let LiveKit / WebRTC manage teardown — we don't force-deactivate here
             // because WebRTC's internal ref-counting will handle it on disconnect.
+            unregisterInterruptionObserver()
             result(nil)
         case "updateMuteState":
             // iOS keeps the audio session alive regardless of mute state — no-op.
@@ -30,12 +35,9 @@ public class DaakiaVcFlutterSdkPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    // Activates AVAudioSession with the same category/mode that WebRTC/LiveKit uses
-    // (.playAndRecord / .videoChat). Calling this when the meeting starts ensures
-    // iOS keeps the app alive in the background under the `audio` UIBackgroundMode
-    // even when the user's microphone is muted, because the session is active for
-    // audio playback of remote participants.
-    private func activateAudioSession() {
+    // Activates the audio session. Returns true on success, false if still interrupted.
+    @discardableResult
+    private func activateAudioSession() -> Bool {
         let session = AVAudioSession.sharedInstance()
         do {
             try session.setCategory(
@@ -44,8 +46,105 @@ public class DaakiaVcFlutterSdkPlugin: NSObject, FlutterPlugin {
                 options: [.allowBluetooth, .allowBluetoothA2DP, .defaultToSpeaker]
             )
             try session.setActive(true)
+            return true
         } catch {
-            print("DaakiaMeetingService: audio session activation failed — \(error)")
+            return false
+        }
+    }
+
+    private func registerInterruptionObserver() {
+        let session = AVAudioSession.sharedInstance()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAudioInterruption(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: session
+        )
+        // iOS 16+ often skips AVAudioSessionInterruptionTypeEnded after phone calls.
+        // didBecomeActive covers the case where the app was backgrounded during the call.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        // Dynamic Island calls: app stays in foreground the whole time, so
+        // didBecomeActive never fires. Route change is the only reliable signal
+        // that the call released the audio session.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleRouteChange(_:)),
+            name: AVAudioSession.routeChangeNotification,
+            object: session
+        )
+    }
+
+    private func unregisterInterruptionObserver() {
+        let session = AVAudioSession.sharedInstance()
+        NotificationCenter.default.removeObserver(self, name: AVAudioSession.interruptionNotification, object: session)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: AVAudioSession.routeChangeNotification, object: session)
+        isInterrupted = false
+    }
+
+    // Called by iOS when a phone call (or other audio interruption) begins or ends.
+    // On `.ended` we reactivate AVAudioSession and tell Flutter so it can restart
+    // the LiveKit microphone track — without this, WebRTC never resumes capturing
+    // even though the track is still "enabled" from LiveKit's perspective.
+    @objc private func handleAudioInterruption(_ notification: Notification) {
+        guard let info = notification.userInfo,
+              let typeValue = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else {
+            return
+        }
+
+        if type == .began {
+            isInterrupted = true
+            channel?.invokeMethod("audioInterruptionBegan", arguments: nil)
+            return
+        }
+
+        // .ended path — not reliable on iOS 16+ for phone calls; handleAppDidBecomeActive
+        // and handleRouteChange are the primary recovery paths.
+        guard type == .ended else { return }
+
+        var shouldResume = true
+        if let optionsValue = info[AVAudioSessionInterruptionOptionKey] as? UInt {
+            shouldResume = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+                .contains(.shouldResume)
+        }
+        guard shouldResume else { return }
+
+        recoverAudioSession()
+    }
+
+    // Fires when the user returns from a backgrounded phone call.
+    @objc private func handleAppDidBecomeActive() {
+        guard isInterrupted else { return }
+        recoverAudioSession()
+    }
+
+    // Fires when the audio route changes — the only reliable signal when a Dynamic
+    // Island call ends while the app stays in the foreground.
+    @objc private func handleRouteChange(_ notification: Notification) {
+        guard isInterrupted else { return }
+        guard notification.userInfo?[AVAudioSessionRouteChangeReasonKey] is UInt else { return }
+        recoverAudioSession()
+    }
+
+    private func recoverAudioSession() {
+        guard isInterrupted else { return }
+        // Do NOT clear isInterrupted yet — only clear it if activation succeeds.
+        // This prevents the mic button from unlocking while the call is still active.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            guard let self = self, self.isInterrupted else { return }
+            if self.activateAudioSession() {
+                // Session is ours again — call has truly ended.
+                self.isInterrupted = false
+                self.channel?.invokeMethod("audioInterruptionEnded", arguments: nil)
+            }
+            // If activation failed the call is still active; isInterrupted stays true
+            // and the next route change / didBecomeActive will retry.
         }
     }
 }

--- a/ios/Classes/DaakiaVcFlutterSdkPlugin.swift
+++ b/ios/Classes/DaakiaVcFlutterSdkPlugin.swift
@@ -36,14 +36,22 @@ public class DaakiaVcFlutterSdkPlugin: NSObject, FlutterPlugin {
     }
 
     // Activates the audio session. Returns true on success, false if still interrupted.
+    // When force=false (the default), skips reconfiguration if LiveKit has already
+    // set the session to .playAndRecord — reconfiguring mid-capture disrupts the
+    // WebRTC audio pipeline and causes the mic to go silent despite appearing unmuted.
+    // Set force=true only when recovering from a phone-call interruption, where the
+    // session must be explicitly reclaimed.
     @discardableResult
-    private func activateAudioSession() -> Bool {
+    private func activateAudioSession(force: Bool = false) -> Bool {
         let session = AVAudioSession.sharedInstance()
+        if !force && session.category == .playAndRecord {
+            return true
+        }
         do {
             try session.setCategory(
                 .playAndRecord,
                 mode: .videoChat,
-                options: [.allowBluetooth, .allowBluetoothA2DP, .defaultToSpeaker]
+                options: [.allowBluetooth, .allowBluetoothA2DP, .allowAirPlay]
             )
             try session.setActive(true)
             return true
@@ -138,7 +146,7 @@ public class DaakiaVcFlutterSdkPlugin: NSObject, FlutterPlugin {
         // This prevents the mic button from unlocking while the call is still active.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             guard let self = self, self.isInterrupted else { return }
-            if self.activateAudioSession() {
+            if self.activateAudioSession(force: true) {
                 // Session is ours again — call has truly ended.
                 self.isInterrupted = false
                 self.channel?.invokeMethod("audioInterruptionEnded", arguments: nil)

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -215,6 +215,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
 
   bool _isReconnecting = false;
   bool _isConnected = false;
+  bool _isPhoneCallActive = false;
 
   late final TransformationController _zoomController;
   double _zoomScale = 1.0;
@@ -855,6 +856,34 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     DaakiaMeetingService.onEndCall = () {
       if (mounted) closeMeetingProgrammatically(context);
     };
+    if (lkPlatformIs(PlatformType.iOS)) {
+      DaakiaMeetingService.onAudioInterruptionBegan = () => _handleAudioInterruptionBegan();
+      DaakiaMeetingService.onAudioInterruptionEnded = _handleAudioInterruptionEnded;
+    }
+  }
+
+  Future<void> _handleAudioInterruptionBegan() async {
+    final vm = _livekitProviderKey.currentState?.viewModel;
+    if (vm == null || !mounted) return;
+    vm.setAudioInterrupted(true);
+    setState(() => _isPhoneCallActive = true);
+    // Mute the LiveKit track so other participants see the user as muted,
+    // not "mic on but silent" for the duration of the phone call.
+    final participant = widget.room.localParticipant;
+    if (participant != null && participant.isMicrophoneEnabled()) {
+      await participant.setMicrophoneEnabled(false);
+    }
+  }
+
+  // After a phone-call interruption ends on iOS, AVAudioSession has been reactivated
+  // by the native side. The mic is left OFF — the user decides when to re-enable it.
+  void _handleAudioInterruptionEnded() {
+    final vm = _livekitProviderKey.currentState?.viewModel;
+    if (vm != null && mounted) {
+      vm.setAudioInterrupted(false);
+      setState(() => _isPhoneCallActive = false);
+      showSnackBar(message: "Phone call ended");
+    }
   }
 
   Future<void> _handleNotificationMuteToggle() async {
@@ -1285,6 +1314,16 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
                         child: ConnectivityBanner(
                           message: "You’re back online",
                           backgroundColor: Colors.green,
+                        ),
+                      ),
+                    if (_isPhoneCallActive)
+                      const Positioned(
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        child: ConnectivityBanner(
+                          message: "Phone call in progress — audio unavailable",
+                          backgroundColor: Colors.orange,
                         ),
                       ),
                   ],

--- a/lib/rtc/widgets/rtc_controls.dart
+++ b/lib/rtc/widgets/rtc_controls.dart
@@ -118,6 +118,7 @@ class _RtcControlState extends State<RtcControls> {
           ),
           IconButton(
             onPressed: () {
+              if (viewModel.isAudioInterrupted) return;
               final isHostOrCoHost = viewModel.isHost() ||
                   viewModel.isCoHost();
 

--- a/lib/service/daakia_meeting_service.dart
+++ b/lib/service/daakia_meeting_service.dart
@@ -17,6 +17,11 @@ class DaakiaMeetingService {
   static VoidCallback? onMuteToggle;
   static VoidCallback? onEndCall;
 
+  // Fired on iOS when a phone call (or other audio interruption) begins or ends.
+  // RoomPage uses these to disable/re-enable the mic button and restart the track.
+  static VoidCallback? onAudioInterruptionBegan;
+  static VoidCallback? onAudioInterruptionEnded;
+
   /// Must be called once (e.g. in RoomPage.initState) before any [start] call
   /// so that notification button presses from Android are dispatched back here.
   static void initialize() {
@@ -30,6 +35,12 @@ class DaakiaMeetingService {
         break;
       case 'onEndCall':
         onEndCall?.call();
+        break;
+      case 'audioInterruptionBegan':
+        onAudioInterruptionBegan?.call();
+        break;
+      case 'audioInterruptionEnded':
+        onAudioInterruptionEnded?.call();
         break;
     }
   }
@@ -137,6 +148,8 @@ class DaakiaMeetingService {
     _showMuteButton = false;
     onMuteToggle = null;
     onEndCall = null;
+    onAudioInterruptionBegan = null;
+    onAudioInterruptionEnded = null;
     try {
       await _channel.invokeMethod('stopMeetingService');
     } catch (e) {

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -64,6 +64,15 @@ class RtcViewmodel extends ChangeNotifier {
 
   bool _isMeetingEnded = false;
 
+  // True while an iOS audio session interruption (e.g. phone call) is active.
+  // The mic button is disabled during this window.
+  bool isAudioInterrupted = false;
+
+  void setAudioInterrupted(bool value) {
+    isAudioInterrupted = value;
+    notifyListeners();
+  }
+
   // Getter
   bool get isMeetingEnded => _isMeetingEnded;
 
@@ -418,6 +427,7 @@ class RtcViewmodel extends ChangeNotifier {
   }
 
   double getMicAlpha() {
+    if (isAudioInterrupted) return 0.5;
     if (isHost() || isCoHost()) return 1.0;
     if (!isAudioPermissionEnable) {
       return isMicPermissionGranted ? 1.0 : 0.5;


### PR DESCRIPTION
## Summary

This PR improves iOS audio interruption handling during phone calls and enhances audio session recovery for RTC meetings.

## Changes

- Added native iOS handling for `AVAudioSession` interruptions and phone call detection.
- Added observers for:
  - `AVAudioSession.interruptionNotification`
  - `UIApplication.didBecomeActiveNotification`
  - `AVAudioSession.routeChangeNotification`
- Updated `DaakiaMeetingService` and `RoomPage` to handle interruption events via method channels.
- Automatically mutes the local microphone and disables mic controls during active phone calls.
- Added `ConnectivityBanner` to notify users when audio is unavailable due to interruptions.
- Implemented audio session recovery logic after interruptions end.
- Updated `activateAudioSession` to avoid unnecessary audio session reconfiguration.
- Added `force` parameter support to explicitly reclaim audio sessions after phone calls.
- Updated `AVAudioSession` configuration to include `.allowAirPlay` and remove `.defaultToSpeaker`.