### PR TITLE
Feat/screen-share-annotation-preview

### DIFF
--- a/lib/model/annotation_stroke.dart
+++ b/lib/model/annotation_stroke.dart
@@ -1,0 +1,39 @@
+class AnnotationStroke {
+  final String id;
+  final String fromIdentity;
+  final String tool; // pen | highlighter | line | rectangle | arrow
+  final String color; // '#rrggbb'
+  final double width;
+  final List<List<double>> points; // [[x, y, pressure], ...] — normalised 0–1
+
+  const AnnotationStroke({
+    required this.id,
+    required this.fromIdentity,
+    required this.tool,
+    required this.color,
+    required this.width,
+    required this.points,
+  });
+
+  factory AnnotationStroke.fromJson(Map<String, dynamic> json) {
+    return AnnotationStroke(
+      id: json['id'] as String,
+      fromIdentity: json['fromIdentity'] as String? ?? '',
+      tool: json['tool'] as String,
+      color: json['color'] as String,
+      width: (json['width'] as num).toDouble(),
+      points: (json['points'] as List)
+          .map((p) => (p as List).map((v) => (v as num).toDouble()).toList())
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'fromIdentity': fromIdentity,
+        'tool': tool,
+        'color': color,
+        'width': width,
+        'points': points,
+      };
+}

--- a/lib/presentation/widgets/annotation_toolbar.dart
+++ b/lib/presentation/widgets/annotation_toolbar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:livekit_client/livekit_client.dart';
 import 'package:provider/provider.dart';
 
+import '../../utils/annotation_actions.dart';
 import '../../viewmodel/rtc_viewmodel.dart';
 
 const _annotationColors = [
@@ -64,7 +65,7 @@ class AnnotationToolbar extends StatelessWidget {
                   final stroke = viewModel.undoLastAnnotationStroke(sharerIdentity, localId);
                   if (stroke != null) {
                     await viewModel.publishAnnotationData(room, {
-                      'action': 'annotation_remove',
+                      'action': AnnotationActions.remove,
                       'sharerIdentity': sharerIdentity,
                       'ids': [stroke.id],
                     });
@@ -78,7 +79,7 @@ class AnnotationToolbar extends StatelessWidget {
                 onTap: () async {
                   viewModel.clearAnnotationStrokes(sharerIdentity);
                   await viewModel.publishAnnotationData(room, {
-                    'action': 'annotation_clear',
+                    'action': AnnotationActions.clear,
                     'sharerIdentity': sharerIdentity,
                   });
                 },

--- a/lib/presentation/widgets/annotation_toolbar.dart
+++ b/lib/presentation/widgets/annotation_toolbar.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+import 'package:livekit_client/livekit_client.dart';
+import 'package:provider/provider.dart';
+
+import '../../viewmodel/rtc_viewmodel.dart';
+
+const _annotationColors = [
+  '#FF0000',
+  '#FF8C00',
+  '#FFFF00',
+  '#00CC44',
+  '#0066FF',
+  '#9900CC',
+  '#000000',
+  '#FFFFFF',
+  '#FF69B4',
+];
+
+const _annotationWidths = [2.0, 4.0, 8.0, 14.0];
+
+class AnnotationToolbar extends StatelessWidget {
+  final String sharerIdentity;
+  final Room room;
+
+  const AnnotationToolbar({
+    super.key,
+    required this.sharerIdentity,
+    required this.room,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<RtcViewmodel>(builder: (context, viewModel, _) {
+      return Container(
+        decoration: BoxDecoration(
+          color: Colors.black.withValues(alpha: 0.75),
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Tool buttons
+              _ToolButton(tool: 'pen', icon: Icons.edit, viewModel: viewModel),
+              _ToolButton(tool: 'highlighter', icon: Icons.highlight, viewModel: viewModel),
+              _ToolButton(tool: 'line', icon: Icons.horizontal_rule, viewModel: viewModel),
+              _ToolButton(tool: 'rectangle', icon: Icons.crop_square, viewModel: viewModel),
+              _ToolButton(tool: 'arrow', icon: Icons.arrow_right_alt, viewModel: viewModel),
+              const _Divider(),
+              // Color swatches
+              ..._annotationColors.map((c) => _ColorButton(color: c, viewModel: viewModel)),
+              const _Divider(),
+              // Stroke width buttons
+              ..._annotationWidths.map((w) => _WidthButton(width: w, viewModel: viewModel)),
+              const _Divider(),
+              // Undo
+              _ActionButton(
+                icon: Icons.undo,
+                tooltip: 'Undo',
+                onTap: () async {
+                  final localId = room.localParticipant?.identity ?? '';
+                  final stroke = viewModel.undoLastAnnotationStroke(sharerIdentity, localId);
+                  if (stroke != null) {
+                    await viewModel.publishAnnotationData(room, {
+                      'action': 'annotation_remove',
+                      'sharerIdentity': sharerIdentity,
+                      'ids': [stroke.id],
+                    });
+                  }
+                },
+              ),
+              // Clear all
+              _ActionButton(
+                icon: Icons.delete_sweep,
+                tooltip: 'Clear all',
+                onTap: () async {
+                  viewModel.clearAnnotationStrokes(sharerIdentity);
+                  await viewModel.publishAnnotationData(room, {
+                    'action': 'annotation_clear',
+                    'sharerIdentity': sharerIdentity,
+                  });
+                },
+              ),
+              // Close annotation mode
+              _ActionButton(
+                icon: Icons.close,
+                tooltip: 'Close',
+                onTap: () => viewModel.setAnnotationActive(false),
+              ),
+            ],
+          ),
+        ),
+      );
+    });
+  }
+}
+
+class _ToolButton extends StatelessWidget {
+  final String tool;
+  final IconData icon;
+  final RtcViewmodel viewModel;
+
+  const _ToolButton({
+    required this.tool,
+    required this.icon,
+    required this.viewModel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isActive = viewModel.annotationTool == tool;
+    return GestureDetector(
+      onTap: () => viewModel.setAnnotationTool(tool),
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 3),
+        padding: const EdgeInsets.all(6),
+        decoration: BoxDecoration(
+          color: isActive ? Colors.white.withValues(alpha: 0.25) : Colors.transparent,
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Icon(icon, color: Colors.white, size: 20),
+      ),
+    );
+  }
+}
+
+class _ColorButton extends StatelessWidget {
+  final String color;
+  final RtcViewmodel viewModel;
+
+  const _ColorButton({required this.color, required this.viewModel});
+
+  Color get _parsedColor {
+    final hex = color.replaceFirst('#', '');
+    return Color(int.parse('FF$hex', radix: 16));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isActive = viewModel.annotationColor == color;
+    return GestureDetector(
+      onTap: () => viewModel.setAnnotationColor(color),
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 3),
+        width: 22,
+        height: 22,
+        decoration: BoxDecoration(
+          color: _parsedColor,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: isActive ? Colors.white : Colors.white38,
+            width: isActive ? 2.5 : 1,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WidthButton extends StatelessWidget {
+  final double width;
+  final RtcViewmodel viewModel;
+
+  const _WidthButton({required this.width, required this.viewModel});
+
+  @override
+  Widget build(BuildContext context) {
+    final isActive = viewModel.annotationWidth == width;
+    final dotSize = (width * 0.8).clamp(3.0, 12.0);
+    return GestureDetector(
+      onTap: () => viewModel.setAnnotationWidth(width),
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 4),
+        width: 28,
+        height: 28,
+        decoration: BoxDecoration(
+          color: isActive ? Colors.white.withValues(alpha: 0.2) : Colors.transparent,
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Center(
+          child: Container(
+            width: dotSize,
+            height: dotSize,
+            decoration: const BoxDecoration(
+              color: Colors.white,
+              shape: BoxShape.circle,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onTap;
+
+  const _ActionButton({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 3),
+          padding: const EdgeInsets.all(6),
+          child: Icon(icon, color: Colors.white, size: 20),
+        ),
+      ),
+    );
+  }
+}
+
+class _Divider extends StatelessWidget {
+  const _Divider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 4),
+      width: 1,
+      height: 24,
+      color: Colors.white30,
+    );
+  }
+}

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -35,6 +35,7 @@ import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
 
+import '../model/annotation_stroke.dart';
 import '../model/emoji_message.dart';
 import '../model/remote_activity_data.dart';
 import '../presentation/dialog/screen_share_request_dialog.dart';
@@ -463,6 +464,8 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
       var viewModel = _livekitProviderKey.currentState?.viewModel;
       final localParticipant = widget.room.localParticipant;
       if (localParticipant?.isScreenShareEnabled() == true) {
+        // Reset any prior annotation state for the local sharer
+        viewModel?.resetAnnotationSharer(localParticipant!.identity);
         viewModel?.sendAction(ActionModel(
             action: MeetingActions.screenShareStarted,
             timeStamp: DateTime.now().microsecondsSinceEpoch));
@@ -470,6 +473,11 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
       _sortParticipants();
     })
     ..on<LocalTrackUnpublishedEvent>((track){
+      if (track.publication.source == TrackSource.screenShareVideo) {
+        final viewModel = _livekitProviderKey.currentState?.viewModel;
+        final localId = widget.room.localParticipant?.identity;
+        if (localId != null) viewModel?.resetAnnotationSharer(localId);
+      }
       _sortParticipants();
     })
     ..on<TrackSubscribedEvent>((_) => _sortParticipants())
@@ -495,10 +503,78 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
       }
     });
 
+  static const _annotationActions = {
+    'annotation_stroke',
+    'annotation_remove',
+    'annotation_clear',
+    'annotation_snapshot',
+    'annotation_snapshot_request',
+  };
+
   void _handleDataChannel(DataReceivedEvent event) {
+    // Intercept annotation messages before MeetingActions validation
+    try {
+      final json = jsonDecode(utf8.decode(event.data)) as Map<String, dynamic>;
+      if (_annotationActions.contains(json['action'])) {
+        _handleAnnotationData(json, event.participant);
+        return;
+      }
+    } catch (_) {}
+
     var eventData0 = parseJsonData(event.data);
     var eventData = eventData0.copyWith(identity: event.participant);
     _checkReceivedDataType(eventData);
+  }
+
+  void _handleAnnotationData(
+      Map<String, dynamic> data, RemoteParticipant? participant) {
+    final viewModel = _livekitProviderKey.currentState?.viewModel;
+    if (viewModel == null) return;
+
+    final action = data['action'] as String;
+    final sharerIdentity =
+        (data['sharerIdentity'] as String?) ?? participant?.identity ?? '';
+    if (sharerIdentity.isEmpty) return;
+
+    final localIdentity = widget.room.localParticipant?.identity ?? '';
+
+    // Ignore echo from self, except snapshot_request (sharer must respond to own unicast)
+    if (participant?.identity == localIdentity &&
+        action != 'annotation_snapshot_request') return;
+
+    switch (action) {
+      case 'annotation_stroke':
+        final raw = data['stroke'] as Map<String, dynamic>?;
+        if (raw == null) return;
+        final stroke = AnnotationStroke.fromJson({
+          ...raw,
+          'fromIdentity': raw['fromIdentity'] ?? participant?.identity ?? '',
+        });
+        viewModel.addAnnotationStroke(sharerIdentity, stroke);
+
+      case 'annotation_remove':
+        final ids = List<String>.from(data['ids'] ?? []);
+        viewModel.removeAnnotationStrokes(sharerIdentity, ids);
+
+      case 'annotation_clear':
+        viewModel.clearAnnotationStrokes(sharerIdentity);
+
+      case 'annotation_snapshot':
+        final strokes = (data['strokes'] as List? ?? [])
+            .map((s) => AnnotationStroke.fromJson(s as Map<String, dynamic>))
+            .toList();
+        viewModel.replaceAnnotationStrokes(sharerIdentity, strokes);
+
+      case 'annotation_snapshot_request':
+        final requesterIdentity =
+            (data['requesterIdentity'] as String?) ?? participant?.identity ?? '';
+        if (localIdentity == sharerIdentity &&
+            requesterIdentity.isNotEmpty &&
+            requesterIdentity != localIdentity) {
+          viewModel.publishAnnotationSnapshot(
+              widget.room, sharerIdentity, [requesterIdentity]);
+        }
+    }
   }
 
   late LobbyRequestManager? lobbyManager;
@@ -702,10 +778,15 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
 
       case MeetingActions.screenShareStarted:
         showSnackBar(message: "${remoteData.identity?.name} has started sharing their screen.");
+        // Clear any stale annotation strokes from a previous share session
+        final startedSharerId = remoteData.identity?.identity;
+        if (startedSharerId != null) viewModel?.clearAnnotationStrokes(startedSharerId);
         break;
 
       case MeetingActions.screenShareStopped:
         showSnackBar(message: "${remoteData.identity?.name} has stopped sharing their screen.");
+        final stoppedSharerId = remoteData.identity?.identity;
+        if (stoppedSharerId != null) viewModel?.resetAnnotationSharer(stoppedSharerId);
         break;
 
       case MeetingActions.startRecording:

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -41,6 +41,7 @@ import '../model/remote_activity_data.dart';
 import '../presentation/dialog/screen_share_request_dialog.dart';
 import '../presentation/pages/transcription_screen.dart';
 import '../utils/consent_status_enum.dart';
+import '../utils/annotation_actions.dart';
 import '../utils/meeting_actions.dart';
 import '../utils/utils.dart';
 import 'meeting_manager.dart';
@@ -503,19 +504,11 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
       }
     });
 
-  static const _annotationActions = {
-    'annotation_stroke',
-    'annotation_remove',
-    'annotation_clear',
-    'annotation_snapshot',
-    'annotation_snapshot_request',
-  };
-
   void _handleDataChannel(DataReceivedEvent event) {
     // Intercept annotation messages before MeetingActions validation
     try {
       final json = jsonDecode(utf8.decode(event.data)) as Map<String, dynamic>;
-      if (_annotationActions.contains(json['action'])) {
+      if (AnnotationActions.all.contains(json['action'])) {
         _handleAnnotationData(json, event.participant);
         return;
       }
@@ -538,12 +531,12 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
 
     final localIdentity = widget.room.localParticipant?.identity ?? '';
 
-    // Ignore echo from self, except snapshot_request (sharer must respond to own unicast)
+    // Ignore echo from self, except snapshotRequest (sharer must respond to own unicast)
     if (participant?.identity == localIdentity &&
-        action != 'annotation_snapshot_request') return;
+        action != AnnotationActions.snapshotRequest) return;
 
     switch (action) {
-      case 'annotation_stroke':
+      case AnnotationActions.stroke:
         final raw = data['stroke'] as Map<String, dynamic>?;
         if (raw == null) return;
         final stroke = AnnotationStroke.fromJson({
@@ -552,20 +545,20 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         });
         viewModel.addAnnotationStroke(sharerIdentity, stroke);
 
-      case 'annotation_remove':
+      case AnnotationActions.remove:
         final ids = List<String>.from(data['ids'] ?? []);
         viewModel.removeAnnotationStrokes(sharerIdentity, ids);
 
-      case 'annotation_clear':
+      case AnnotationActions.clear:
         viewModel.clearAnnotationStrokes(sharerIdentity);
 
-      case 'annotation_snapshot':
+      case AnnotationActions.snapshot:
         final strokes = (data['strokes'] as List? ?? [])
             .map((s) => AnnotationStroke.fromJson(s as Map<String, dynamic>))
             .toList();
         viewModel.replaceAnnotationStrokes(sharerIdentity, strokes);
 
-      case 'annotation_snapshot_request':
+      case AnnotationActions.snapshotRequest:
         final requesterIdentity =
             (data['requesterIdentity'] as String?) ?? participant?.identity ?? '';
         if (localIdentity == sharerIdentity &&

--- a/lib/rtc/widgets/annotation_overlay.dart
+++ b/lib/rtc/widgets/annotation_overlay.dart
@@ -1,0 +1,366 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
+import 'package:livekit_client/livekit_client.dart';
+import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../model/annotation_stroke.dart';
+import '../../viewmodel/rtc_viewmodel.dart';
+import 'annotation_painter.dart';
+
+class AnnotationOverlay extends StatefulWidget {
+  final TrackPublication publication;
+  final Participant participant;
+  final String sharerIdentity;
+  final String trackSid;
+  final Room room;
+
+  const AnnotationOverlay({
+    super.key,
+    required this.publication,
+    required this.participant,
+    required this.sharerIdentity,
+    required this.trackSid,
+    required this.room,
+  });
+
+  @override
+  State<AnnotationOverlay> createState() => _AnnotationOverlayState();
+}
+
+class _AnnotationOverlayState extends State<AnnotationOverlay> {
+  Size _videoSize = Size.zero;
+  EventsListener<TrackEvent>? _trackListener;
+  rtc.RTCVideoRenderer? _dimRenderer;
+
+  @override
+  void initState() {
+    super.initState();
+    _readDimensions();
+    widget.participant.addListener(_onParticipantChanged);
+    _setupStatsListener();
+    _initDimRenderer();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _requestSnapshotIfNeeded());
+  }
+
+  @override
+  void didUpdateWidget(covariant AnnotationOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.participant != widget.participant) {
+      oldWidget.participant.removeListener(_onParticipantChanged);
+      widget.participant.addListener(_onParticipantChanged);
+    }
+    if (oldWidget.publication != widget.publication) {
+      _trackListener?.dispose();
+      _trackListener = null;
+      _readDimensions();
+      _setupStatsListener();
+      _disposeDimRenderer();
+      _initDimRenderer();
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.participant.removeListener(_onParticipantChanged);
+    _trackListener?.dispose();
+    _disposeDimRenderer();
+    super.dispose();
+  }
+
+  /// Creates a hidden RTCVideoRenderer attached to the track's media stream.
+  /// Its onResize fires at the exact same instant as VideoTrackRenderer's
+  /// internal renderer — when the native layer delivers the first video frame.
+  void _initDimRenderer() {
+    final mediaStream = widget.publication.track?.mediaStream;
+    if (mediaStream == null) return;
+    final renderer = rtc.RTCVideoRenderer();
+    _dimRenderer = renderer;
+    renderer.initialize().then((_) {
+      if (!mounted || _dimRenderer != renderer) {
+        try {
+          renderer.dispose();
+        } catch (_) {}
+        return;
+      }
+      try {
+        renderer.srcObject = mediaStream;
+        renderer.onResize = () {
+          if (!mounted) return;
+          final w = renderer.videoWidth;
+          final h = renderer.videoHeight;
+          if (w > 0 && h > 0) {
+            final newSize = Size(w.toDouble(), h.toDouble());
+            if (newSize != _videoSize) setState(() => _videoSize = newSize);
+          }
+        };
+      } catch (e) {
+        // ignore — renderer may have been disposed concurrently
+      }
+    });
+  }
+
+  void _disposeDimRenderer() {
+    final r = _dimRenderer;
+    _dimRenderer = null;
+    if (r == null) return;
+    try {
+      r.onResize = null;
+      r.srcObject = null;
+      r.dispose();
+    } catch (_) {}
+  }
+
+  void _onParticipantChanged() {
+    final prev = _videoSize;
+    _readDimensions();
+    if (_videoSize != prev && mounted) setState(() {});
+  }
+
+  /// Reads video dimensions from the publication meta-data.
+  /// - Remote: uses `videoDimensions` set from server-side track info.
+  /// - Local: uses the configured capture parameters.
+  void _readDimensions() {
+    final pub = widget.publication;
+    if (pub is RemoteTrackPublication) {
+      final dims = pub.videoDimensions;
+      if (dims != null) {
+        _videoSize = Size(dims.width.toDouble(), dims.height.toDouble());
+      }
+    } else if (pub is LocalTrackPublication) {
+      final track = pub.track;
+      if (track is LocalVideoTrack) {
+        final dims = track.currentOptions.params.dimensions;
+        _videoSize = Size(dims.width.toDouble(), dims.height.toDouble());
+      }
+    }
+  }
+
+  /// Secondary listener: stats events fire once video frames are flowing and
+  /// give us the actual decoded frame size (most accurate for remote tracks).
+  void _setupStatsListener() {
+    final track = widget.publication.track;
+    if (track == null) return;
+    _trackListener = track.createListener();
+    if (track is RemoteVideoTrack) {
+      _trackListener!.on<VideoReceiverStatsEvent>((event) {
+        final w = event.stats.frameWidth;
+        final h = event.stats.frameHeight;
+        if (w != null && h != null && mounted) {
+          final newSize = Size(w.toDouble(), h.toDouble());
+          if (newSize != _videoSize) setState(() => _videoSize = newSize);
+        }
+      });
+    } else if (track is LocalVideoTrack) {
+      _trackListener!.on<VideoSenderStatsEvent>((event) {
+        final s = event.stats['f'] ?? event.stats['h'] ?? event.stats['q'];
+        final w = s?.frameWidth;
+        final h = s?.frameHeight;
+        if (w != null && h != null && mounted) {
+          final newSize = Size(w.toDouble(), h.toDouble());
+          if (newSize != _videoSize) setState(() => _videoSize = newSize);
+        }
+      });
+    }
+  }
+
+  void _requestSnapshotIfNeeded() {
+    if (!mounted) return;
+    final viewModel = context.read<RtcViewmodel>();
+    final localIdentity = widget.room.localParticipant?.identity ?? '';
+    if (widget.sharerIdentity == localIdentity) return;
+
+    final key = '${widget.sharerIdentity}:${widget.trackSid}';
+    if (viewModel.hasRequestedAnnotationSnapshot(key)) return;
+    viewModel.markAnnotationSnapshotRequested(key);
+
+    viewModel.publishAnnotationData(
+      widget.room,
+      {
+        'action': 'annotation_snapshot_request',
+        'requesterIdentity': localIdentity,
+        'sharerIdentity': widget.sharerIdentity,
+      },
+      destinationIdentities: [widget.sharerIdentity],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<RtcViewmodel>(builder: (context, viewModel, _) {
+      final strokes = viewModel.getAnnotationStrokes(widget.sharerIdentity);
+      final isAnnotationForThisShare = viewModel.isAnnotationActive &&
+          viewModel.activeAnnotationSharerIdentity == widget.sharerIdentity;
+
+      return LayoutBuilder(builder: (context, constraints) {
+        final containerWidth = constraints.maxWidth;
+        final containerHeight = constraints.maxHeight;
+
+        final bounds = _videoSize == Size.zero
+            ? VideoContentBounds(
+                left: 0,
+                top: 0,
+                width: containerWidth,
+                height: containerHeight)
+            : getRenderedVideoContentBounds(
+                containerWidth: containerWidth,
+                containerHeight: containerHeight,
+                videoWidth: _videoSize.width,
+                videoHeight: _videoSize.height,
+              );
+
+        return Stack(children: [
+          // Committed strokes — always visible, never interactive
+          IgnorePointer(
+            child: CustomPaint(
+              size: Size(containerWidth, containerHeight),
+              painter: AnnotationPainter(strokes: strokes, bounds: bounds),
+            ),
+          ),
+          // Drawing input layer — only when this user is annotating this share
+          if (isAnnotationForThisShare)
+            _AnnotationInputLayer(
+              bounds: bounds,
+              sharerIdentity: widget.sharerIdentity,
+              room: widget.room,
+            ),
+        ]);
+      });
+    });
+  }
+}
+
+class _AnnotationInputLayer extends StatefulWidget {
+  final VideoContentBounds bounds;
+  final String sharerIdentity;
+  final Room room;
+
+  const _AnnotationInputLayer({
+    required this.bounds,
+    required this.sharerIdentity,
+    required this.room,
+  });
+
+  @override
+  State<_AnnotationInputLayer> createState() => _AnnotationInputLayerState();
+}
+
+class _AnnotationInputLayerState extends State<_AnnotationInputLayer> {
+  List<List<double>> _currentPoints = [];
+  List<List<double>> _shapePreviewPoints = [];
+  String? _currentStrokeId;
+
+  @override
+  void didUpdateWidget(covariant _AnnotationInputLayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // If video content bounds changed mid-stroke, the already-captured points
+    // are normalised against the old coordinate system. Discard to avoid
+    // misaligned strokes being sent to remote participants.
+    if (oldWidget.bounds != widget.bounds && _currentStrokeId != null) {
+      _currentStrokeId = null;
+      _currentPoints = [];
+      _shapePreviewPoints = [];
+    }
+  }
+
+  bool get _isFreehandTool {
+    final tool = context.read<RtcViewmodel>().annotationTool;
+    return tool == 'pen' || tool == 'highlighter';
+  }
+
+  void _onPointerDown(PointerDownEvent e) {
+    final norm = canvasToNormalised(e.localPosition, widget.bounds);
+    if (norm == null) return;
+    _currentStrokeId = const Uuid().v4();
+    _currentPoints = [norm];
+    _shapePreviewPoints = [norm, norm];
+    setState(() {});
+  }
+
+  void _onPointerMove(PointerMoveEvent e) {
+    if (_currentStrokeId == null) return;
+    final norm = canvasToNormalised(e.localPosition, widget.bounds);
+    if (norm == null) return;
+    if (_isFreehandTool) {
+      _currentPoints.add(norm);
+    } else {
+      _shapePreviewPoints = [_currentPoints.first, norm];
+    }
+    setState(() {});
+  }
+
+  Future<void> _onPointerUp(PointerUpEvent e) async {
+    if (_currentStrokeId == null) return;
+    final viewModel = context.read<RtcViewmodel>();
+    final tool = viewModel.annotationTool;
+
+    final finalPoints = _isFreehandTool
+        ? List<List<double>>.from(_currentPoints)
+        : List<List<double>>.from(_shapePreviewPoints);
+
+    _currentStrokeId = null;
+    _currentPoints = [];
+    _shapePreviewPoints = [];
+
+    if (finalPoints.isEmpty) {
+      setState(() {});
+      return;
+    }
+
+    final stroke = AnnotationStroke(
+      id: const Uuid().v4(),
+      fromIdentity: widget.room.localParticipant?.identity ?? '',
+      tool: tool,
+      color: viewModel.annotationColor,
+      width: viewModel.annotationWidth,
+      points: finalPoints,
+    );
+
+    viewModel.addAnnotationStroke(widget.sharerIdentity, stroke);
+    await viewModel.publishAnnotationData(
+      widget.room,
+      {
+        'action': 'annotation_stroke',
+        'sharerIdentity': widget.sharerIdentity,
+        'stroke': stroke.toJson(),
+      },
+    );
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = context.watch<RtcViewmodel>();
+    final tool = viewModel.annotationTool;
+
+    final previewStrokes = <AnnotationStroke>[];
+    if (_currentStrokeId != null) {
+      final pts = (tool == 'pen' || tool == 'highlighter')
+          ? _currentPoints
+          : _shapePreviewPoints;
+      if (pts.isNotEmpty) {
+        previewStrokes.add(AnnotationStroke(
+          id: _currentStrokeId!,
+          fromIdentity: '',
+          tool: tool,
+          color: viewModel.annotationColor,
+          width: viewModel.annotationWidth,
+          points: pts,
+        ));
+      }
+    }
+
+    return Listener(
+      onPointerDown: _onPointerDown,
+      onPointerMove: _onPointerMove,
+      onPointerUp: _onPointerUp,
+      child: CustomPaint(
+        painter: AnnotationPainter(
+          strokes: previewStrokes,
+          bounds: widget.bounds,
+        ),
+        child: const SizedBox.expand(),
+      ),
+    );
+  }
+}

--- a/lib/rtc/widgets/annotation_overlay.dart
+++ b/lib/rtc/widgets/annotation_overlay.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../model/annotation_stroke.dart';
+import '../../utils/annotation_actions.dart';
 import '../../viewmodel/rtc_viewmodel.dart';
 import 'annotation_painter.dart';
 
@@ -177,7 +178,7 @@ class _AnnotationOverlayState extends State<AnnotationOverlay> {
     viewModel.publishAnnotationData(
       widget.room,
       {
-        'action': 'annotation_snapshot_request',
+        'action': AnnotationActions.snapshotRequest,
         'requesterIdentity': localIdentity,
         'sharerIdentity': widget.sharerIdentity,
       },
@@ -320,7 +321,7 @@ class _AnnotationInputLayerState extends State<_AnnotationInputLayer> {
     await viewModel.publishAnnotationData(
       widget.room,
       {
-        'action': 'annotation_stroke',
+        'action': AnnotationActions.stroke,
         'sharerIdentity': widget.sharerIdentity,
         'stroke': stroke.toJson(),
       },

--- a/lib/rtc/widgets/annotation_overlay.dart
+++ b/lib/rtc/widgets/annotation_overlay.dart
@@ -73,6 +73,7 @@ class _AnnotationOverlayState extends State<AnnotationOverlay> {
   /// Its onResize fires at the exact same instant as VideoTrackRenderer's
   /// internal renderer — when the native layer delivers the first video frame.
   void _initDimRenderer() {
+    if (_dimRenderer != null) return;
     final mediaStream = widget.publication.track?.mediaStream;
     if (mediaStream == null) return;
     final renderer = rtc.RTCVideoRenderer();
@@ -116,6 +117,10 @@ class _AnnotationOverlayState extends State<AnnotationOverlay> {
     final prev = _videoSize;
     _readDimensions();
     if (_videoSize != prev && mounted) setState(() {});
+    // Track may have been null at initState (not yet subscribed). Retry both
+    // setups whenever the participant notifies — they guard against double-init.
+    if (_trackListener == null) _setupStatsListener();
+    if (_dimRenderer == null) _initDimRenderer();
   }
 
   /// Reads video dimensions from the publication meta-data.
@@ -140,6 +145,7 @@ class _AnnotationOverlayState extends State<AnnotationOverlay> {
   /// Secondary listener: stats events fire once video frames are flowing and
   /// give us the actual decoded frame size (most accurate for remote tracks).
   void _setupStatsListener() {
+    if (_trackListener != null) return;
     final track = widget.publication.track;
     if (track == null) return;
     _trackListener = track.createListener();

--- a/lib/rtc/widgets/annotation_painter.dart
+++ b/lib/rtc/widgets/annotation_painter.dart
@@ -1,0 +1,210 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../model/annotation_stroke.dart';
+
+class VideoContentBounds {
+  final double left;
+  final double top;
+  final double width;
+  final double height;
+
+  const VideoContentBounds({
+    required this.left,
+    required this.top,
+    required this.width,
+    required this.height,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is VideoContentBounds &&
+      other.left == left &&
+      other.top == top &&
+      other.width == width &&
+      other.height == height;
+
+  @override
+  int get hashCode => Object.hash(left, top, width, height);
+}
+
+/// Calculates the actual rendered video area inside a container, accounting
+/// for letterboxing (object-fit: contain equivalent).
+VideoContentBounds getRenderedVideoContentBounds({
+  required double containerWidth,
+  required double containerHeight,
+  required double videoWidth,
+  required double videoHeight,
+}) {
+  if (containerWidth <= 0 ||
+      containerHeight <= 0 ||
+      videoWidth <= 0 ||
+      videoHeight <= 0) {
+    return VideoContentBounds(
+        left: 0, top: 0, width: containerWidth, height: containerHeight);
+  }
+
+  final containerAspect = containerWidth / containerHeight;
+  final videoAspect = videoWidth / videoHeight;
+
+  double renderWidth, renderHeight, offsetX, offsetY;
+
+  if (containerAspect > videoAspect) {
+    // Black bars on left and right
+    renderHeight = containerHeight;
+    renderWidth = containerHeight * videoAspect;
+    offsetX = (containerWidth - renderWidth) / 2;
+    offsetY = 0;
+  } else {
+    // Black bars on top and bottom
+    renderWidth = containerWidth;
+    renderHeight = containerWidth / videoAspect;
+    offsetX = 0;
+    offsetY = (containerHeight - renderHeight) / 2;
+  }
+
+  return VideoContentBounds(
+    left: offsetX,
+    top: offsetY,
+    width: renderWidth,
+    height: renderHeight,
+  );
+}
+
+/// Scales stroke width proportionally relative to a 720px reference height.
+double getStrokeContentScale(double contentHeight) {
+  const referenceHeight = 720.0;
+  return contentHeight / referenceHeight;
+}
+
+/// Converts a normalised coordinate (0–1) to a canvas pixel offset.
+Offset normalisedToCanvas(double nx, double ny, VideoContentBounds bounds) {
+  return Offset(
+    bounds.left + nx * bounds.width,
+    bounds.top + ny * bounds.height,
+  );
+}
+
+/// Converts a canvas pixel offset to a normalised coordinate (0–1).
+/// Returns null if the point is outside the video content area.
+List<double>? canvasToNormalised(Offset position, VideoContentBounds bounds) {
+  final nx = (position.dx - bounds.left) / bounds.width;
+  final ny = (position.dy - bounds.top) / bounds.height;
+  if (nx < 0 || nx > 1 || ny < 0 || ny > 1) return null;
+  return [nx, ny, 0.5]; // pressure defaults to 0.5 on mobile
+}
+
+class AnnotationPainter extends CustomPainter {
+  final List<AnnotationStroke> strokes;
+  final VideoContentBounds bounds;
+
+  const AnnotationPainter({required this.strokes, required this.bounds});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final scale = getStrokeContentScale(bounds.height);
+    for (final stroke in strokes) {
+      _drawStroke(canvas, stroke, scale);
+    }
+  }
+
+  void _drawStroke(Canvas canvas, AnnotationStroke stroke, double scale) {
+    if (stroke.points.isEmpty) return;
+
+    final color = _parseColor(stroke.color);
+    final paint = Paint()
+      ..color = stroke.tool == 'highlighter'
+          ? color.withValues(alpha: 0.35)
+          : color
+      ..strokeWidth = stroke.width * scale
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..style = PaintingStyle.stroke;
+
+    switch (stroke.tool) {
+      case 'pen':
+      case 'highlighter':
+        _drawFreehand(canvas, stroke.points, paint);
+      case 'line':
+        if (stroke.points.length < 2) return;
+        final p1 = normalisedToCanvas(
+            stroke.points.first[0], stroke.points.first[1], bounds);
+        final p2 = normalisedToCanvas(
+            stroke.points.last[0], stroke.points.last[1], bounds);
+        canvas.drawLine(p1, p2, paint);
+      case 'rectangle':
+        if (stroke.points.length < 2) return;
+        final p1 = normalisedToCanvas(
+            stroke.points.first[0], stroke.points.first[1], bounds);
+        final p2 = normalisedToCanvas(
+            stroke.points.last[0], stroke.points.last[1], bounds);
+        canvas.drawRect(Rect.fromPoints(p1, p2), paint);
+      case 'arrow':
+        if (stroke.points.length < 2) return;
+        _drawArrow(canvas, stroke.points, paint, scale);
+    }
+  }
+
+  void _drawFreehand(
+      Canvas canvas, List<List<double>> points, Paint paint) {
+    if (points.length == 1) {
+      final p = normalisedToCanvas(points[0][0], points[0][1], bounds);
+      canvas.drawCircle(
+          p, paint.strokeWidth / 2, paint..style = PaintingStyle.fill);
+      return;
+    }
+
+    final path = Path();
+    final first = normalisedToCanvas(points[0][0], points[0][1], bounds);
+    path.moveTo(first.dx, first.dy);
+
+    for (int i = 1; i < points.length - 1; i++) {
+      final curr =
+          normalisedToCanvas(points[i][0], points[i][1], bounds);
+      final next =
+          normalisedToCanvas(points[i + 1][0], points[i + 1][1], bounds);
+      final midX = (curr.dx + next.dx) / 2;
+      final midY = (curr.dy + next.dy) / 2;
+      path.quadraticBezierTo(curr.dx, curr.dy, midX, midY);
+    }
+
+    final last = normalisedToCanvas(points.last[0], points.last[1], bounds);
+    path.lineTo(last.dx, last.dy);
+    canvas.drawPath(path, paint..style = PaintingStyle.stroke);
+  }
+
+  void _drawArrow(Canvas canvas, List<List<double>> points, Paint paint,
+      double scale) {
+    final p1 =
+        normalisedToCanvas(points.first[0], points.first[1], bounds);
+    final p2 =
+        normalisedToCanvas(points.last[0], points.last[1], bounds);
+    canvas.drawLine(p1, p2, paint);
+
+    final angle = (p2 - p1).direction;
+    final arrowSize = 12.0 * scale;
+    const arrowAngle = 0.45; // radians
+    final path = Path();
+    path.moveTo(p2.dx, p2.dy);
+    path.lineTo(
+      p2.dx - arrowSize * math.cos(angle - arrowAngle),
+      p2.dy - arrowSize * math.sin(angle - arrowAngle),
+    );
+    path.moveTo(p2.dx, p2.dy);
+    path.lineTo(
+      p2.dx - arrowSize * math.cos(angle + arrowAngle),
+      p2.dy - arrowSize * math.sin(angle + arrowAngle),
+    );
+    canvas.drawPath(path, paint);
+  }
+
+  Color _parseColor(String hex) {
+    final cleaned = hex.replaceFirst('#', '');
+    return Color(int.parse('FF$cleaned', radix: 16));
+  }
+
+  @override
+  bool shouldRepaint(AnnotationPainter oldDelegate) =>
+      oldDelegate.strokes != strokes || oldDelegate.bounds != bounds;
+}

--- a/lib/rtc/widgets/participant.dart
+++ b/lib/rtc/widgets/participant.dart
@@ -272,27 +272,29 @@ abstract class _ParticipantWidgetState<T extends ParticipantWidget>
                   ),
                 ),
               ),
+            //TODO: Will think about this later [Mobile collaboration]
             // Annotation launch button — pencil icon in top-right corner of screen-share tile
             // Hidden when annotation is already active for this share
-            if (isScreenShare && !isAnnotationForThisShare)
-              Positioned(
-                top: 8,
-                right: 8,
-                child: GestureDetector(
-                  onTap: () => viewModel.setAnnotationActive(
-                    true,
-                    sharerIdentity: widget.participant.identity,
-                  ),
-                  child: Container(
-                    padding: const EdgeInsets.all(7),
-                    decoration: BoxDecoration(
-                      color: Colors.black.withValues(alpha: 0.6),
-                      shape: BoxShape.circle,
-                    ),
-                    child: const Icon(Icons.edit, color: Colors.white, size: 18),
-                  ),
-                ),
-              ),
+            // if (isScreenShare && !isAnnotationForThisShare)
+            //   Positioned(
+            //     top: 8,
+            //     right: 8,
+            //     child: GestureDetector(
+            //       onTap: () => viewModel.setAnnotationActive(
+            //         true,
+            //         sharerIdentity: widget.participant.identity,
+            //       ),
+            //       child: Container(
+            //         padding: const EdgeInsets.all(7),
+            //         decoration: BoxDecoration(
+            //           color: Colors.black.withValues(alpha: 0.6),
+            //           shape: BoxShape.circle,
+            //         ),
+            //         child: const Icon(Icons.edit, color: Colors.white, size: 18),
+            //       ),
+            //     ),
+            //   ),
+
             // Local screen-share blur — suppressed when annotation is active so the
             // sharer can see what they're annotating on
             if (widget.isSpeaker &&

--- a/lib/rtc/widgets/participant.dart
+++ b/lib/rtc/widgets/participant.dart
@@ -7,8 +7,10 @@ import 'package:flutter/material.dart';
 import 'package:livekit_client/livekit_client.dart';
 import 'package:provider/provider.dart';
 
+import '../../presentation/widgets/annotation_toolbar.dart';
 import '../../resources/colors/color.dart';
 import '../../viewmodel/rtc_viewmodel.dart';
+import 'annotation_overlay.dart';
 import 'no_video.dart';
 import 'participant_info.dart';
 
@@ -145,6 +147,10 @@ abstract class _ParticipantWidgetState<T extends ParticipantWidget>
   @override
   Widget build(BuildContext ctx) {
     final viewModel = Provider.of<RtcViewmodel>(context);
+    final isAnnotationForThisShare = isScreenShare &&
+        viewModel.isAnnotationActive &&
+        viewModel.activeAnnotationSharerIdentity == widget.participant.identity;
+
     return Card(
       elevation: 10,
       color: emptyVideoColor,
@@ -179,6 +185,17 @@ abstract class _ParticipantWidgetState<T extends ParticipantWidget>
                       isSpeaker: widget.isSpeaker,
                     ),
             ),
+            // Annotation overlay — renders remote strokes + drawing input on screen-share tiles
+            if (isScreenShare && videoPublication != null)
+              Positioned.fill(
+                child: AnnotationOverlay(
+                  publication: videoPublication!,
+                  participant: widget.participant,
+                  sharerIdentity: widget.participant.identity,
+                  trackSid: videoPublication?.sid ?? '',
+                  room: viewModel.room,
+                ),
+              ),
             // Bottom bar
             Align(
               alignment: Alignment.bottomCenter,
@@ -186,6 +203,12 @@ abstract class _ParticipantWidgetState<T extends ParticipantWidget>
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  // Annotation toolbar — shown at bottom of tile when annotation is active
+                  if (isAnnotationForThisShare)
+                    AnnotationToolbar(
+                      sharerIdentity: widget.participant.identity,
+                      room: viewModel.room,
+                    ),
                   // ...extraWidgets(isScreenShare),
                   ParticipantInfoWidget(
                     title: widget.participant.name.isNotEmpty
@@ -219,7 +242,7 @@ abstract class _ParticipantWidgetState<T extends ParticipantWidget>
                   decoration: BoxDecoration(
                     color: Colors.black.withValues(alpha: 0.6),
                     borderRadius: BorderRadius.circular(
-                      widget.isSpeaker ? 50 : 12, // ← true capsule for speaker
+                      widget.isSpeaker ? 50 : 12,
                     ),
                     border: Border.all(
                       color: handRaiseColor,
@@ -249,9 +272,33 @@ abstract class _ParticipantWidgetState<T extends ParticipantWidget>
                   ),
                 ),
               ),
+            // Annotation launch button — pencil icon in top-right corner of screen-share tile
+            // Hidden when annotation is already active for this share
+            if (isScreenShare && !isAnnotationForThisShare)
+              Positioned(
+                top: 8,
+                right: 8,
+                child: GestureDetector(
+                  onTap: () => viewModel.setAnnotationActive(
+                    true,
+                    sharerIdentity: widget.participant.identity,
+                  ),
+                  child: Container(
+                    padding: const EdgeInsets.all(7),
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.6),
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Icon(Icons.edit, color: Colors.white, size: 18),
+                  ),
+                ),
+              ),
+            // Local screen-share blur — suppressed when annotation is active so the
+            // sharer can see what they're annotating on
             if (widget.isSpeaker &&
                 isScreenShare &&
-                widget.participant is LocalParticipant)
+                widget.participant is LocalParticipant &&
+                !isAnnotationForThisShare)
               Positioned.fill(
                 child: ClipRect(
                   child: BackdropFilter(

--- a/lib/utils/annotation_actions.dart
+++ b/lib/utils/annotation_actions.dart
@@ -1,0 +1,9 @@
+abstract final class AnnotationActions {
+  static const stroke = 'annotation_stroke';
+  static const remove = 'annotation_remove';
+  static const clear = 'annotation_clear';
+  static const snapshot = 'annotation_snapshot';
+  static const snapshotRequest = 'annotation_snapshot_request';
+
+  static const all = {stroke, remove, clear, snapshot, snapshotRequest};
+}

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -22,6 +22,7 @@ import 'package:flutter_background/flutter_background.dart';
 import 'package:livekit_client/livekit_client.dart';
 import 'package:uuid/uuid.dart';
 
+import '../model/annotation_stroke.dart';
 import '../enum/chat_type_enum.dart';
 import '../enum/attendance_role_enum.dart';
 import '../model/action_model.dart';
@@ -2889,6 +2890,133 @@ class RtcViewmodel extends ChangeNotifier {
     } else {
       sendPrivateAction(ActionModel(action: MeetingActions.lowerHand), identity);
     }
+  }
+
+  // ─── Annotation state ────────────────────────────────────────────────────
+
+  final Map<String, List<AnnotationStroke>> _strokesBySharer = {};
+  String? _activeAnnotationSharerIdentity;
+  bool _isAnnotationActive = false;
+  String _annotationTool = 'pen';
+  String _annotationColor = '#FF0000';
+  double _annotationWidth = 4.0;
+  final Set<String> _requestedAnnotationSnapshotKeys = {};
+
+  bool get isAnnotationActive => _isAnnotationActive;
+  String? get activeAnnotationSharerIdentity => _activeAnnotationSharerIdentity;
+  String get annotationTool => _annotationTool;
+  String get annotationColor => _annotationColor;
+  double get annotationWidth => _annotationWidth;
+
+  List<AnnotationStroke> getAnnotationStrokes(String sharerIdentity) =>
+      List.unmodifiable(_strokesBySharer[sharerIdentity] ?? const []);
+
+  bool hasRequestedAnnotationSnapshot(String key) =>
+      _requestedAnnotationSnapshotKeys.contains(key);
+
+  void markAnnotationSnapshotRequested(String key) =>
+      _requestedAnnotationSnapshotKeys.add(key);
+
+  void setAnnotationActive(bool active, {String? sharerIdentity}) {
+    _isAnnotationActive = active;
+    if (active && sharerIdentity != null) {
+      _activeAnnotationSharerIdentity = sharerIdentity;
+    } else if (!active) {
+      _activeAnnotationSharerIdentity = null;
+    }
+    notifyListeners();
+  }
+
+  void setAnnotationTool(String tool) {
+    _annotationTool = tool;
+    notifyListeners();
+  }
+
+  void setAnnotationColor(String color) {
+    _annotationColor = color;
+    notifyListeners();
+  }
+
+  void setAnnotationWidth(double width) {
+    _annotationWidth = width;
+    notifyListeners();
+  }
+
+  void addAnnotationStroke(String sharerIdentity, AnnotationStroke stroke) {
+    final list = _strokesBySharer.putIfAbsent(sharerIdentity, () => []);
+    if (list.any((s) => s.id == stroke.id)) return; // deduplicate
+    list.add(stroke);
+    notifyListeners();
+  }
+
+  void removeAnnotationStrokes(String sharerIdentity, List<String> ids) {
+    _strokesBySharer[sharerIdentity]?.removeWhere((s) => ids.contains(s.id));
+    notifyListeners();
+  }
+
+  void clearAnnotationStrokes(String sharerIdentity) {
+    _strokesBySharer[sharerIdentity]?.clear();
+    notifyListeners();
+  }
+
+  void replaceAnnotationStrokes(
+      String sharerIdentity, List<AnnotationStroke> strokes) {
+    _strokesBySharer[sharerIdentity] = List.from(strokes);
+    notifyListeners();
+  }
+
+  void resetAnnotationSharer(String sharerIdentity) {
+    _strokesBySharer.remove(sharerIdentity);
+    _requestedAnnotationSnapshotKeys
+        .removeWhere((k) => k.startsWith('$sharerIdentity:'));
+    if (_activeAnnotationSharerIdentity == sharerIdentity) {
+      _activeAnnotationSharerIdentity = null;
+      _isAnnotationActive = false;
+    }
+    notifyListeners();
+  }
+
+  /// Removes and returns the last stroke drawn by [localIdentity] for undo.
+  AnnotationStroke? undoLastAnnotationStroke(
+      String sharerIdentity, String localIdentity) {
+    final list = _strokesBySharer[sharerIdentity];
+    if (list == null) return null;
+    final idx = list.lastIndexWhere((s) => s.fromIdentity == localIdentity);
+    if (idx == -1) return null;
+    final stroke = list[idx];
+    list.removeAt(idx);
+    notifyListeners();
+    return stroke;
+  }
+
+  Future<void> publishAnnotationData(
+    Room room,
+    Map<String, dynamic> payload, {
+    List<String>? destinationIdentities,
+  }) async {
+    final encoded = utf8.encode(jsonEncode(payload));
+    await room.localParticipant?.publishData(
+      Uint8List.fromList(encoded),
+      reliable: true,
+      destinationIdentities: destinationIdentities,
+    );
+  }
+
+  Future<void> publishAnnotationSnapshot(
+    Room room,
+    String sharerIdentity,
+    List<String> destinationIdentities,
+  ) async {
+    final strokes = _strokesBySharer[sharerIdentity] ?? [];
+    await publishAnnotationData(
+      room,
+      {
+        'action': 'annotation_snapshot',
+        'sharerIdentity': sharerIdentity,
+        'strokes': strokes.map((s) => s.toJson()).toList(),
+      },
+      destinationIdentities: destinationIdentities,
+    );
   }
 
 }

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -37,6 +37,7 @@ import '../rtc/widgets/participant_info.dart';
 import '../utils/chat_message_mapper.dart';
 import '../utils/consent_status_enum.dart';
 import '../utils/constants.dart';
+import '../utils/annotation_actions.dart';
 import '../utils/meeting_actions.dart';
 
 class RtcViewmodel extends ChangeNotifier {
@@ -3011,7 +3012,7 @@ class RtcViewmodel extends ChangeNotifier {
     await publishAnnotationData(
       room,
       {
-        'action': 'annotation_snapshot',
+        'action': AnnotationActions.snapshot,
         'sharerIdentity': sharerIdentity,
         'strokes': strokes.map((s) => s.toJson()).toList(),
       },


### PR DESCRIPTION
## Summary

This PR introduces real-time screen-share annotation support with drawing tools, annotation synchronization, and overlay rendering capabilities.

## Changes

- Added screen-share annotation support for collaborative drawing over shared content.
- Implemented `AnnotationOverlay` and `AnnotationPainter` for rendering annotation strokes.
- Added `AnnotationStroke` model with serialization support for annotation data.
- Introduced `AnnotationToolbar` with support for:
  - Pen
  - Highlighter
  - Line
  - Rectangle
  - Arrow
- Updated `RtcViewmodel` to manage annotation state, tool selection, stroke history, and synchronization.
- Integrated annotation controls into screen-share participant views.
- Added real-time annotation synchronization using LiveKit data channels.
- Added `AnnotationActions` utility class and migrated annotation action constants.
- Refactored annotation publishing logic to use centralized action constants.
- Fixed annotation overlay track initialization issues.
- Temporarily disabled the annotation launch button on screen-share tiles pending further updates.