### PR TITLE
Feat/participant client platform metadata

### DIFF
--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -378,10 +378,11 @@ class _PreJoinState extends State<PreJoinScreen> {
     if (isParticipant) {
       body["lobby_request_id"] = lobbyRequestId;
     }
-    // Add custom_metadata only if metadata is provided
-    if (widget.configuration?.metadata != null) {
-      body["custom_metadata"] = widget.configuration?.metadata;
-    }
+    // Always include client_platform; merge with any caller-supplied metadata.
+    final Map<String, dynamic> customMetadata =
+        Map<String, dynamic>.from(widget.configuration?.metadata ?? {});
+    customMetadata["client_platform"] = Utils.getClientPlatform();
+    body["custom_metadata"] = customMetadata;
     final cacheData = StorageHelper();
     var tokenFromCache = false;
     if (await cacheData.getMeetingUid() == widget.meetingId) {

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -512,6 +512,36 @@ class Utils {
     return null;
   }
 
+  /// Returns the current platform identifier.
+  ///
+  /// Possible values: `"android"`, `"ios"`, `"macos"`, `"windows"`, `"linux"`, `"web"`.
+  /// Web clients (browser) should pass `"web"` or `"mobile_web"` manually via custom metadata.
+  static String getClientPlatform() {
+    if (kIsWeb) return 'web';
+    if (Platform.isAndroid) return 'android';
+    if (Platform.isIOS) return 'ios';
+    if (Platform.isMacOS) return 'macos';
+    if (Platform.isWindows) return 'windows';
+    if (Platform.isLinux) return 'linux';
+    return 'unknown';
+  }
+
+  static String? extractClientPlatform(String? metadata) {
+    if (metadata == null || metadata.trim().isEmpty) return null;
+
+    try {
+      final Map<String, dynamic> decoded = jsonDecode(metadata);
+      if (decoded['custom_metadata'] is Map) {
+        final platform = decoded['custom_metadata']['client_platform'];
+        if (platform is String && platform.isNotEmpty) return platform;
+      }
+    } catch (_) {
+      return null;
+    }
+
+    return null;
+  }
+
   static String extractMessage(String prefix, dynamic data, String fallback) {
     if (data is Map<String, dynamic> && data['message'] != null) {
       return "$prefix ${data['message']}";


### PR DESCRIPTION
## Summary

This PR adds client platform metadata support during meeting join flows and introduces utilities for platform detection and extraction.

## Changes

- Added `client_platform` to `custom_metadata` in `prejoin_screen.dart`.
- Implemented `getClientPlatform` utility to detect the current platform (Android, iOS, Web, etc.).
- Added `extractClientPlatform` utility to parse platform information from JSON metadata.
- Enhanced meeting participant metadata to include client platform details for downstream processing and analytics.