### PR TITLE
Feat/annotation host controls

### DIFF
--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -16,6 +16,7 @@ import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 
 import '../model/agent_dispatch_data.dart';
+import '../model/host_controls_data.dart';
 import '../model/base_list_response.dart';
 import '../model/base_response.dart';
 import '../model/event_password_protected_data.dart';
@@ -226,6 +227,15 @@ abstract class RestClient {
     @Query("session_id") String sessionId,
   );
 
+  // Returns all host control states in a single call.
+  // Use this instead of the individual GET endpoints below.
+  @GET("rtc/meeting/hostControls")
+  Future<BaseResponse<HostControlsData>> getHostControls(
+    @Header("x-self-identity") String selfIdentity,
+    @Query("meeting_uid") String meetingUid,
+  );
+
+  @Deprecated('Use getHostControls() instead.')
   @GET("rtc/screenShareConsent")
   Future<BaseResponse<ScreenShareConsentModel>> getScreenShareConsent(
     @Header("x-self-identity") String selfIdentity,
@@ -239,6 +249,7 @@ abstract class RestClient {
     @Body() Map<String, dynamic> body,
   );
 
+  @Deprecated('Use getHostControls() instead.')
   @GET("rtc/chatAttachmentDownloadConsent")
   Future<BaseResponse<ChatAttachmentConsentModel>> getChatAttachmentConsent(
     @Header("x-self-identity") String selfIdentity,
@@ -252,6 +263,7 @@ abstract class RestClient {
     @Body() Map<String, dynamic> body,
   );
 
+  @Deprecated('Use getHostControls() instead.')
   @GET("rtc/audioPermission")
   Future<BaseResponse<WebinarPermissionModel>> getAudioPermission(
     @Header("x-self-identity") String selfIdentity,
@@ -265,6 +277,7 @@ abstract class RestClient {
     @Body() Map<String, dynamic> body,
   );
 
+  @Deprecated('Use getHostControls() instead.')
   @GET("rtc/videoPermission")
   Future<BaseResponse<WebinarPermissionModel>> getVideoPermission(
     @Header("x-self-identity") String selfIdentity,
@@ -292,6 +305,7 @@ abstract class RestClient {
     @Body() Map<String, dynamic> body,
   );
 
+  @Deprecated('Use getHostControls() instead.')
   @GET("rtc/meeting/get/participantDrawer")
   Future<BaseResponse<ParticipantDrawerConsentModel>> getParticipantDrawerConsent(
     @Header("x-self-identity") String selfIdentity,

--- a/lib/api/api_client.g.dart
+++ b/lib/api/api_client.g.dart
@@ -1142,6 +1142,40 @@ class _RestClient implements RestClient {
   }
 
   @override
+  Future<BaseResponse<HostControlsData>> getHostControls(
+    String selfIdentity,
+    String meetingUid,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'meeting_uid': meetingUid};
+    final _headers = <String, dynamic>{r'x-self-identity': selfIdentity};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<BaseResponse<HostControlsData>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            'rtc/meeting/hostControls',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseResponse<HostControlsData> _value;
+    try {
+      _value = BaseResponse<HostControlsData>.fromJson(
+        _result.data!,
+        (json) => HostControlsData.fromJson(json as Map<String, dynamic>),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
   Future<BaseResponse<ScreenShareConsentModel>> getScreenShareConsent(
     String selfIdentity,
     String meetingId,

--- a/lib/model/host_controls_data.dart
+++ b/lib/model/host_controls_data.dart
@@ -1,0 +1,44 @@
+class HostControlsData {
+  final bool annotationAllowed;
+  final bool audioPermission;
+  final bool autoMeetingEnd;
+  final bool chatAttachmentDownloadEnabled;
+  final bool participantDrawer;
+  final bool screenSharePermissionGranted;
+  final bool videoPermission;
+  final bool whiteboardCollaborationEnabled;
+  final bool isRecordingActive;
+
+  const HostControlsData({
+    required this.annotationAllowed,
+    required this.audioPermission,
+    required this.autoMeetingEnd,
+    required this.chatAttachmentDownloadEnabled,
+    required this.participantDrawer,
+    required this.screenSharePermissionGranted,
+    required this.videoPermission,
+    required this.whiteboardCollaborationEnabled,
+    required this.isRecordingActive,
+  });
+
+  factory HostControlsData.fromJson(Map<String, dynamic> json) {
+    bool parseBool(String key, {bool fallback = false}) {
+      final v = json[key];
+      if (v is bool) return v;
+      if (v is int) return v == 1;
+      return fallback;
+    }
+
+    return HostControlsData(
+      annotationAllowed: parseBool('annotation_allowed'),
+      audioPermission: parseBool('audio_permission'),
+      autoMeetingEnd: parseBool('auto_meeting_end'),
+      chatAttachmentDownloadEnabled: parseBool('chat_attachment_download_enabled'),
+      participantDrawer: parseBool('participant_drawer'),
+      screenSharePermissionGranted: parseBool('screen_share_permission_granted', fallback: true),
+      videoPermission: parseBool('video_permission'),
+      whiteboardCollaborationEnabled: parseBool('whiteboard_collaboration_enabled'),
+      isRecordingActive: parseBool('is_recording_active'),
+    );
+  }
+}

--- a/lib/presentation/dialog/pariticipant_dialog_controls.dart
+++ b/lib/presentation/dialog/pariticipant_dialog_controls.dart
@@ -309,9 +309,12 @@ class CustomTextItem extends StatelessWidget {
             children: [
               Icon(icon, color: Colors.white, size: 22),
               const SizedBox(width: 12),
-              Text(
-                text,
-                style: const TextStyle(fontSize: 16, color: Colors.white),
+              Flexible(
+                child: Text(
+                  text,
+                  style: const TextStyle(fontSize: 16, color: Colors.white),
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
             ],
           ),

--- a/lib/presentation/dialog/pariticipant_dialog_controls.dart
+++ b/lib/presentation/dialog/pariticipant_dialog_controls.dart
@@ -136,7 +136,7 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
                 onTap: () {
                   Navigator.pop(context);
                   if (targetIsOnMobile) {
-                    Utils.showSnackBar(context, message: "Annotation is not supported on mobile devices.");
+                    _showAnnotationUnavailableDialog(context);
                     return;
                   }
                   widget.viewModel.updateAnnotationPermissionForParticipant(
@@ -231,6 +231,60 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
               //       widget.viewModel.meetingDetails.features!
               //           .isRaiseHandAllowed(),
               // ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showAnnotationUnavailableDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (ctx) => Dialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        backgroundColor: Colors.white,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 52,
+                height: 52,
+                decoration: const BoxDecoration(
+                  color: Color(0xFFECECF8),
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(Icons.draw_outlined, color: Color(0xFF7B7BED), size: 24),
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                "Annotation Unavailable",
+                style: TextStyle(fontSize: 17, fontWeight: FontWeight.bold, color: Colors.black87),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 10),
+              const Text(
+                "This Participant is using a mobile device. Annotation is available only on desktop/laptop device.",
+                style: TextStyle(fontSize: 14, color: Colors.black54, height: 1.4),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 22),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () => Navigator.of(ctx).pop(),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF7B7BED),
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    elevation: 0,
+                  ),
+                  child: const Text("Got it", style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600)),
+                ),
+              ),
             ],
           ),
         ),

--- a/lib/presentation/dialog/pariticipant_dialog_controls.dart
+++ b/lib/presentation/dialog/pariticipant_dialog_controls.dart
@@ -45,6 +45,8 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
     final bool videoPermissionGranted = Utils.isVideoEnabled(widget.participant.attributes);
     final bool isCoHost = Utils.isCoHost(widget.participant.metadata);
     final bool isPinned = widget.viewModel.pinnedParticipantId == widget.participant.identity;
+    final bool annotationPermissionGranted = Utils.isAnnotationAllowed(widget.participant.attributes);
+    final bool targetIsOnMobile = Utils.isMobilePlatform(widget.participant.metadata);
 
     return Dialog(
       shape: RoundedRectangleBorder(
@@ -125,6 +127,22 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
                     (!Utils.isHost(targetRoleMataData) && !Utils.isCoHost(targetRoleMataData)) &&
                     (Utils.isHost(myRoleMataData) ||
                         Utils.isCoHost(myRoleMataData))),
+              ),
+              CustomTextItem(
+                icon: annotationPermissionGranted ? Icons.draw : Icons.draw_outlined,
+                text: annotationPermissionGranted
+                    ? "Revoke Annotation Permission"
+                    : "Allow Annotation Permission",
+                onTap: () {
+                  Navigator.pop(context);
+                  widget.viewModel.updateAnnotationPermissionForParticipant(
+                      widget.participant.identity, !annotationPermissionGranted);
+                },
+                isVisible: widget.isForIndividual &&
+                    widget.viewModel.isAnnotationEnabled &&
+                    !targetIsOnMobile &&
+                    (!Utils.isHost(targetRoleMataData) && !Utils.isCoHost(targetRoleMataData)) &&
+                    (Utils.isHost(myRoleMataData) || Utils.isCoHost(myRoleMataData)),
               ),
               CustomTextItem(
                 icon: isCoHost ? Icons.remove_moderator : Icons.admin_panel_settings,

--- a/lib/presentation/dialog/pariticipant_dialog_controls.dart
+++ b/lib/presentation/dialog/pariticipant_dialog_controls.dart
@@ -135,12 +135,15 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
                     : "Allow Annotation Permission",
                 onTap: () {
                   Navigator.pop(context);
+                  if (targetIsOnMobile) {
+                    Utils.showSnackBar(context, message: "Annotation is not supported on mobile devices.");
+                    return;
+                  }
                   widget.viewModel.updateAnnotationPermissionForParticipant(
                       widget.participant.identity, !annotationPermissionGranted);
                 },
                 isVisible: widget.isForIndividual &&
                     widget.viewModel.isAnnotationEnabled &&
-                    !targetIsOnMobile &&
                     (!Utils.isHost(targetRoleMataData) && !Utils.isCoHost(targetRoleMataData)) &&
                     (Utils.isHost(myRoleMataData) || Utils.isCoHost(myRoleMataData)),
               ),

--- a/lib/presentation/pages/webinar_controls.dart
+++ b/lib/presentation/pages/webinar_controls.dart
@@ -126,6 +126,20 @@ class WebinarControls extends StatelessWidget {
                 },
               ),
 
+              const Divider(color: Colors.white),
+
+              // Screen Share Annotation
+              HostControlSwitch(
+                title: 'Allow Annotation',
+                subtitle:
+                'If turned ON, host can grant individual participants permission to annotate the shared screen.',
+                value: viewModel.isAnnotationEnabled,
+                isEnable: viewModel.meetingDetails.features?.isBasicPlan() == false,
+                onChanged: (value) {
+                  viewModel.updateAnnotationConsent(value);
+                },
+              ),
+
               // Screen Share
               HostControlSwitch(
                 title: 'Allow Screen Share',
@@ -140,19 +154,6 @@ class WebinarControls extends StatelessWidget {
                   viewModel.updateScreenShareConsent(value);
                 },
                 isDividerRequired: false,
-              ),
-
-              // Screen Share Annotation
-              HostControlSwitch(
-                title: 'Allow Annotation',
-                subtitle:
-                    'If turned ON, host can grant individual participants permission to annotate the shared screen.',
-                value: viewModel.isAnnotationEnabled,
-                isEnable: viewModel.meetingDetails.features?.isBasicPlan() == false,
-                isChild: true,
-                onChanged: (value) {
-                  viewModel.updateAnnotationConsent(value);
-                },
               ),
             ],
           ),

--- a/lib/presentation/pages/webinar_controls.dart
+++ b/lib/presentation/pages/webinar_controls.dart
@@ -139,6 +139,20 @@ class WebinarControls extends StatelessWidget {
                   viewModel.isScreenShareEnable = value;
                   viewModel.updateScreenShareConsent(value);
                 },
+                isDividerRequired: false,
+              ),
+
+              // Screen Share Annotation
+              HostControlSwitch(
+                title: 'Allow Annotation',
+                subtitle:
+                    'If turned ON, host can grant individual participants permission to annotate the shared screen.',
+                value: viewModel.isAnnotationEnabled,
+                isEnable: viewModel.meetingDetails.features?.isBasicPlan() == false,
+                isChild: true,
+                onChanged: (value) {
+                  viewModel.updateAnnotationConsent(value);
+                },
               ),
             ],
           ),

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -184,6 +184,20 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         if (vm.meetingDetails.features?.isConferenceChatAttachmentAllowed() == true) {
           vm.getChatAttachmentConsent();
         }
+
+        // TODO(annotation-consent): Once the backend exposes a GET endpoint for
+        // annotation consent (e.g. GET /rtc/meeting/annotationConsent), call it here
+        // so late-joiners and rejoining hosts see the correct initial state.
+        //
+        // Pattern to follow (same as getScreenShareConsent above):
+        //   1. Add @GET("rtc/meeting/annotationConsent") to api_client.dart
+        //   2. Add a response model (or reuse BaseResponse<dynamic> and read success/data)
+        //   3. Add getAnnotationConsent() to RtcViewmodel — set isAnnotationEnabled from response
+        //   4. Uncomment and call it here, gated on the annotation feature flag when added:
+        //
+        // if (vm.meetingDetails.features?.isBasicPlan() == false) {
+        //   vm.getAnnotationConsent();
+        // }
       });
 
       DaakiaPiP.createPipVideoCall(
@@ -872,6 +886,20 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         viewModel?.isVideoPermissionGranted = false;
         viewModel?.disableVideo();
         showSnackBar(message: "Your video permission has been revoked");
+        break;
+
+      case MeetingActions.allowScreenShareAnnotation:
+        viewModel?.isAnnotationEnabled = remoteData.value == true;
+        break;
+
+      case MeetingActions.allowAnnotationPermission:
+        viewModel?.isAnnotationPermissionGranted = true;
+        showSnackBar(message: "You can now annotate the shared screen");
+        break;
+
+      case MeetingActions.revokeAnnotationPermission:
+        viewModel?.isAnnotationPermissionGranted = false;
+        showSnackBar(message: "Your annotation permission has been revoked");
         break;
 
       case MeetingActions.hideParticipantDrawer:

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -166,39 +166,9 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         viewModel?.fetchAndStoreSessionUid();
       }
 
-      // Wave 1 – critical permissions needed before the UI is interactive
-      viewModel?.getAudioPermission();
-      viewModel?.getVideoPermission();
-      viewModel?.getParticipantDrawerConsent();
-
-      // Wave 2 – secondary data, staggered to avoid flooding the server
-      Future.delayed(const Duration(milliseconds: 600), () {
-        if (!mounted) return;
-        var vm = _livekitProviderKey.currentState?.viewModel;
-        if (vm == null) return;
-
-        if (vm.meetingDetails.features?.isScreenShareRequestAllowed() == true) {
-          vm.getScreenShareConsent();
-        }
-
-        if (vm.meetingDetails.features?.isConferenceChatAttachmentAllowed() == true) {
-          vm.getChatAttachmentConsent();
-        }
-
-        // TODO(annotation-consent): Once the backend exposes a GET endpoint for
-        // annotation consent (e.g. GET /rtc/meeting/annotationConsent), call it here
-        // so late-joiners and rejoining hosts see the correct initial state.
-        //
-        // Pattern to follow (same as getScreenShareConsent above):
-        //   1. Add @GET("rtc/meeting/annotationConsent") to api_client.dart
-        //   2. Add a response model (or reuse BaseResponse<dynamic> and read success/data)
-        //   3. Add getAnnotationConsent() to RtcViewmodel — set isAnnotationEnabled from response
-        //   4. Uncomment and call it here, gated on the annotation feature flag when added:
-        //
-        // if (vm.meetingDetails.features?.isBasicPlan() == false) {
-        //   vm.getAnnotationConsent();
-        // }
-      });
+      // Single call fetches all host control states; falls back to individual APIs if endpoint unavailable.
+      // ignore: deprecated_member_use
+      viewModel?.getHostControls();
 
       DaakiaPiP.createPipVideoCall(
           name: widget.room.localParticipant?.name ?? "Unknown",

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -575,6 +575,17 @@ class Utils {
     return _toBool(value);
   }
 
+  static bool isAnnotationAllowed(Map<String, dynamic>? attributes) {
+    final value = attributes?['annotation_allowed'];
+    return _toBool(value);
+  }
+
+  static bool isMobilePlatform(String? metadata) {
+    final platform = extractClientPlatform(metadata);
+    if (platform == null) return false;
+    return platform == 'android' || platform == 'ios' || platform == 'mobile_web';
+  }
+
   static bool _toBool(dynamic value) {
     if (value == null) return false;
 

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2247,6 +2247,45 @@ class RtcViewmodel extends ChangeNotifier {
     notifyListeners();
   }
 
+  // Fetches all host control states in a single request.
+  // Falls back to the individual deprecated methods if the unified endpoint is unavailable (pre-prod).
+  void getHostControls() {
+    networkRequestHandler(
+      apiCall: () => apiClient.getHostControls(selfIdentity, meetingDetails.meetingUid),
+      onSuccess: (data) {
+        if (data == null) {
+          _fallbackToIndividualHostControlAPIs();
+          return;
+        }
+        isAnnotationEnabled = data.annotationAllowed;
+        isAudioModeEnable = data.audioPermission;
+        isAudioPermissionEnable = !data.audioPermission;
+        isChatAttachmentDownloadEnable = data.chatAttachmentDownloadEnabled;
+        isParticipantDrawerHidden = data.participantDrawer;
+        isScreenShareEnable = data.screenSharePermissionGranted;
+        isVideoModeEnable = data.videoPermission;
+        isVideoPermissionEnable = !data.videoPermission;
+        //if (data.isRecordingActive) setRecording(true); NOTE: Not Needed
+      },
+      onError: (_) => _fallbackToIndividualHostControlAPIs(),
+    );
+  }
+
+  // ignore: deprecated_member_use_from_same_package
+  void _fallbackToIndividualHostControlAPIs() {
+    // ignore: deprecated_member_use_from_same_package
+    getAudioPermission();
+    // ignore: deprecated_member_use_from_same_package
+    getVideoPermission();
+    // ignore: deprecated_member_use_from_same_package
+    getParticipantDrawerConsent();
+    // ignore: deprecated_member_use_from_same_package
+    getScreenShareConsent();
+    // ignore: deprecated_member_use_from_same_package
+    getChatAttachmentConsent();
+  }
+
+  @Deprecated('Use getHostControls() instead.')
   void getScreenShareConsent() {
     networkRequestHandler(
         apiCall: ()=> apiClient.getScreenShareConsent(selfIdentity, meetingDetails.meetingUid),
@@ -2379,6 +2418,7 @@ class RtcViewmodel extends ChangeNotifier {
     notifyListeners();
   }
 
+  @Deprecated('Use getHostControls() instead.')
   void getChatAttachmentConsent() {
     networkRequestHandler(
         apiCall: ()=> apiClient.getChatAttachmentConsent(selfIdentity, meetingDetails.meetingUid),
@@ -2455,6 +2495,7 @@ class RtcViewmodel extends ChangeNotifier {
     notifyListeners();
   }
 
+  @Deprecated('Use getHostControls() instead.')
   void getAudioPermission() {
     networkRequestHandler(
         apiCall: ()=> apiClient.getAudioPermission(selfIdentity, meetingDetails.meetingUid),
@@ -2491,6 +2532,7 @@ class RtcViewmodel extends ChangeNotifier {
     );
   }
 
+  @Deprecated('Use getHostControls() instead.')
   void getVideoPermission() {
     networkRequestHandler(
         apiCall: ()=> apiClient.getVideoPermission(selfIdentity, meetingDetails.meetingUid),
@@ -2584,6 +2626,7 @@ class RtcViewmodel extends ChangeNotifier {
 
   bool isParticipantPageOpen = false;
 
+  @Deprecated('Use getHostControls() instead.')
   void getParticipantDrawerConsent() {
     networkRequestHandler(
         apiCall: () => apiClient.getParticipantDrawerConsent(selfIdentity, meetingDetails.meetingUid),

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2616,6 +2616,68 @@ class RtcViewmodel extends ChangeNotifier {
     );
   }
 
+  //===============================[Annotation Permission]===============================
+
+  bool _isAnnotationEnabled = false;
+
+  bool get isAnnotationEnabled => _isAnnotationEnabled;
+
+  set isAnnotationEnabled(bool value) {
+    _isAnnotationEnabled = value;
+    notifyListeners();
+  }
+
+  bool _isAnnotationPermissionGranted = false;
+
+  bool get isAnnotationPermissionGranted => _isAnnotationPermissionGranted;
+
+  set isAnnotationPermissionGranted(bool value) {
+    _isAnnotationPermissionGranted = value;
+    notifyListeners();
+  }
+
+  void updateAnnotationConsent(bool value) {
+    final Map<String, dynamic> body = {
+      "meeting_uid": meetingDetails.meetingUid,
+      "annotation_allowed": value,
+    };
+
+    networkRequestHandler(
+      apiCall: () => apiClient.allowAnnotation(meetingDetails.authorizationToken, selfIdentity, body),
+      onSuccess: (data) {
+        if (data?.success != 1) return;
+        isAnnotationEnabled = value;
+        sendAction(ActionModel(action: MeetingActions.allowScreenShareAnnotation, value: value));
+      },
+      onError: (message) {
+        sendMessageToUI(message);
+        isAnnotationEnabled = !value;
+      },
+    );
+  }
+
+  void updateAnnotationPermissionForParticipant(String participantIdentity, bool value) {
+    final Map<String, dynamic> body = {
+      "meeting_uid": meetingDetails.meetingUid,
+      "participant_identity": participantIdentity,
+      "annotation_allowed": value,
+    };
+
+    networkRequestHandler(
+      apiCall: () => apiClient.allowParticipantAnnotation(meetingDetails.authorizationToken, selfIdentity, body),
+      onSuccess: (data) {
+        if (data?.success != 1) return;
+        sendPrivateAction(
+          ActionModel(action: value ? MeetingActions.allowAnnotationPermission : MeetingActions.revokeAnnotationPermission),
+          participantIdentity,
+        );
+      },
+      onError: (message) {
+        sendMessageToUI(message);
+      },
+    );
+  }
+
   //===============================[Live Caption]===============================
 
   @Deprecated("Use handleCaptionTranscription() instead")

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2644,8 +2644,7 @@ class RtcViewmodel extends ChangeNotifier {
 
     networkRequestHandler(
       apiCall: () => apiClient.allowAnnotation(meetingDetails.authorizationToken, selfIdentity, body),
-      onSuccess: (data) {
-        if (data?.success != 1) return;
+      onSuccess: (_) {
         isAnnotationEnabled = value;
         sendAction(ActionModel(action: MeetingActions.allowScreenShareAnnotation, value: value));
       },


### PR DESCRIPTION
## Summary

This PR adds annotation permission management for screen sharing, introduces platform utility helpers, and refactors host control state fetching to use a unified API.

## Changes

- Added annotation and mobile platform utility helper functions.
- Implemented webinar host controls for enabling/disabling screen-share annotations.
- Added annotation consent and participant-level annotation permission management in `RtcViewmodel`.
- Added support for handling annotation-related meeting actions, including grant and revoke permissions.
- Added "Allow/Revoke Annotation Permission" action to participant controls for hosts and co-hosts.
- Restricted annotation support to eligible non-mobile participants.
- Replaced annotation unsupported snackbar with a custom dialog for mobile users.
- Reordered and refined the UI for the "Allow Annotation" webinar control.
- Removed success flag validation from annotation consent network handling.
- Improved participant dialog layout with `Flexible` text and ellipsis overflow handling.
- Added `getHostControls` API to retrieve all host control states in a single request.
- Refactored host control initialization to use the unified endpoint with fallback to legacy APIs when needed.
- Deprecated individual host control and consent fetching endpoints.