### PR TITLE
Feat/audio output device ux android

### DIFF
--- a/lib/presentation/bottom_sheets/audio_output_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/audio_output_bottomsheet.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:livekit_client/livekit_client.dart';
+
+bool isExternalAudioDevice(String label) {
+  final l = label.toLowerCase();
+  return !l.contains('earpiece') &&
+      !l.contains('speakerphone') &&
+      !l.contains('speaker');
+}
+
+class AudioOutputSheet extends StatefulWidget {
+  final bool speakerphoneOn;
+  final List<MediaDevice> initialDevices;
+  final MediaDevice? selectedDevice;
+  final void Function(MediaDevice) onDeviceSelected;
+
+  const AudioOutputSheet({
+    super.key,
+    required this.speakerphoneOn,
+    required this.initialDevices,
+    required this.selectedDevice,
+    required this.onDeviceSelected,
+  });
+
+  @override
+  State<AudioOutputSheet> createState() => _AudioOutputSheetState();
+}
+
+class _AudioOutputSheetState extends State<AudioOutputSheet> {
+  late List<MediaDevice> _devices;
+  StreamSubscription<List<MediaDevice>>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _devices = widget.initialDevices;
+    _subscription =
+        Hardware.instance.onDeviceChange.stream.listen(_onDeviceChange);
+  }
+
+  void _onDeviceChange(List<MediaDevice> devices) {
+    final outputs = devices.where((d) => d.kind == 'audiooutput').toList();
+    if (mounted) setState(() => _devices = outputs);
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  bool _isSelected(MediaDevice device) {
+    if (widget.selectedDevice != null) {
+      return widget.selectedDevice!.deviceId == device.deviceId;
+    }
+    final l = device.label.toLowerCase();
+    final isSpeaker = l.contains('speakerphone') || l.contains('speaker');
+    if (isSpeaker) return widget.speakerphoneOn;
+    if (widget.speakerphoneOn) return false;
+    // speakerphoneOn=false: OS routes to the best external device first
+    // (BT/wired headset), falling back to earpiece when none is connected.
+    final hasExternal = _devices.any((d) => isExternalAudioDevice(d.label));
+    return hasExternal
+        ? isExternalAudioDevice(device.label)
+        : l.contains('earpiece');
+  }
+
+  IconData _iconForDevice(String label) {
+    final l = label.toLowerCase();
+    if (l.contains('bluetooth') ||
+        l.contains('airpods') ||
+        l.contains('wireless')) {
+      return Icons.bluetooth_audio;
+    }
+    if (l.contains('headphone') || l.contains('headset')) return Icons.headset;
+    if (l.contains('speakerphone') || l.contains('speaker')) {
+      return Icons.volume_up;
+    }
+    if (l.contains('earpiece')) return Icons.hearing;
+    return Icons.volume_up;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: Color(0xFF1E1E1E),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 40,
+              height: 4,
+              margin: const EdgeInsets.symmetric(vertical: 12),
+              decoration: BoxDecoration(
+                color: Colors.grey[600],
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const Padding(
+              padding: EdgeInsets.fromLTRB(16, 4, 16, 12),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Audio Output',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+            if (_devices.isEmpty)
+              const Padding(
+                padding: EdgeInsets.fromLTRB(16, 0, 16, 16),
+                child: Text(
+                  'No audio devices found',
+                  style: TextStyle(color: Colors.grey),
+                ),
+              )
+            else
+              ..._devices.map(
+                (device) => _AudioDeviceOption(
+                  icon: _iconForDevice(device.label),
+                  label: device.label,
+                  isSelected: _isSelected(device),
+                  onTap: () => widget.onDeviceSelected(device),
+                ),
+              ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AudioDeviceOption extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _AudioDeviceOption({
+    required this.icon,
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isSelected ? Colors.blue : Colors.white;
+    return ListTile(
+      leading: Icon(icon, color: color),
+      title: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+        ),
+      ),
+      trailing: isSelected ? const Icon(Icons.check, color: Colors.blue) : null,
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -186,7 +186,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     });
 
     if (lkPlatformIs(PlatformType.android)) {
-      Hardware.instance.setSpeakerphoneOn(false);
+      Hardware.instance.setSpeakerphoneOn(true);
     }
 
     if (lkPlatformIsDesktop()) {

--- a/lib/rtc/widgets/rtc_controls.dart
+++ b/lib/rtc/widgets/rtc_controls.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:daakia_vc_flutter_sdk/events/rtc_events.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/bottom_sheets/end_meeting_bottomsheet.dart';
 import 'package:daakia_vc_flutter_sdk/utils/rtc_ext.dart';
@@ -8,6 +10,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
 import '../../resources/colors/color.dart';
+import '../../presentation/bottom_sheets/audio_output_bottomsheet.dart';
 import '../../presentation/bottom_sheets/more_option_bottomsheet.dart';
 import '../../viewmodel/rtc_viewmodel.dart';
 
@@ -35,6 +38,10 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
   PermissionStatus _micOsStatus = PermissionStatus.granted;
   PermissionStatus _cameraOsStatus = PermissionStatus.granted;
 
+  List<MediaDevice> _audioOutputDevices = [];
+  MediaDevice? _selectedOutputDevice;
+  StreamSubscription<List<MediaDevice>>? _deviceSubscription;
+
   LocalParticipant get participant => widget.participant;
 
   @override
@@ -42,15 +49,19 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
     super.initState();
     participant.addListener(_onChange);
     Hardware.instance.enumerateDevices().then(_loadDevices);
+    _deviceSubscription =
+        Hardware.instance.onDeviceChange.stream.listen(_loadDevices);
     WidgetsBinding.instance.addObserver(this);
     _checkOsPermissions();
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    // Re-check after user returns from Settings.
     if (state == AppLifecycleState.resumed) {
       _checkOsPermissions();
+      // Re-enumerate on resume to catch BT/headset changes while backgrounded
+      // (onDeviceChange stream doesn't fire when the app isn't in foreground).
+      Hardware.instance.enumerateDevices().then(_loadDevices);
     }
   }
 
@@ -66,8 +77,12 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
   }
 
   void _loadDevices(List<MediaDevice> devices) async {
+    final outputs =
+        devices.where((d) => d.kind == 'audiooutput').toList();
     if (mounted) {
-      setState(() {});
+      setState(() {
+        _audioOutputDevices = outputs;
+      });
     }
   }
 
@@ -103,10 +118,88 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
     }
   }
 
-  void _setSpeakerphoneOn() {
-    _speakerphoneOn = !_speakerphoneOn;
-    Hardware.instance.setSpeakerphoneOn(_speakerphoneOn);
-    setState(() {});
+  IconData get _audioOutputIcon {
+    if (_selectedOutputDevice != null) {
+      return _iconForDeviceLabel(_selectedOutputDevice!.label);
+    }
+    if (_speakerphoneOn) return Icons.volume_up;
+    // When speakerphoneOn=false the OS routes to the best external device first
+    // (wired headset or BT), falling back to earpiece when none is connected.
+    final external = _audioOutputDevices
+        .where((d) => isExternalAudioDevice(d.label))
+        .firstOrNull;
+    return external != null
+        ? _iconForDeviceLabel(external.label)
+        : Icons.hearing;
+  }
+
+  IconData _iconForDeviceLabel(String label) {
+    final l = label.toLowerCase();
+    if (l.contains('bluetooth') ||
+        l.contains('airpods') ||
+        l.contains('wireless')) {
+      return Icons.bluetooth_audio;
+    }
+    if (l.contains('headphone') || l.contains('headset')) {
+      return Icons.headset;
+    }
+    return Icons.volume_up;
+  }
+
+  Widget _buildAudioOutputButton() {
+    return IconButton(
+      onPressed: Hardware.instance.canSwitchSpeakerphone
+          ? _showAudioOutputSheet
+          : null,
+      icon: Icon(
+        _audioOutputIcon,
+        color: Colors.white.withValues(
+            alpha: Hardware.instance.canSwitchSpeakerphone ? 1.0 : 0.5),
+      ),
+      iconSize: 30,
+    );
+  }
+
+  void _showAudioOutputSheet() {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (ctx) => AudioOutputSheet(
+        speakerphoneOn: _speakerphoneOn,
+        initialDevices: _audioOutputDevices,
+        selectedDevice: _selectedOutputDevice,
+        onDeviceSelected: (device) async {
+          Navigator.pop(ctx);
+          final label = device.label.toLowerCase();
+          if (label.contains('speakerphone') || label.contains('speaker')) {
+            Hardware.instance.setSpeakerphoneOn(true);
+            setState(() {
+              _speakerphoneOn = true;
+              _selectedOutputDevice = null;
+            });
+          } else if (label.contains('earpiece')) {
+            Hardware.instance.setSpeakerphoneOn(false);
+            setState(() {
+              _speakerphoneOn = false;
+              _selectedOutputDevice = null;
+            });
+          } else {
+            // Bluetooth / wired headset — desktop-only API; mobile routes automatically.
+            try {
+              await Hardware.instance.selectAudioOutput(device);
+              setState(() {
+                _selectedOutputDevice = device;
+              });
+            } catch (e) {
+              if (kDebugMode) print('Could not select audio output: $e');
+            }
+          }
+        },
+      ),
+    );
   }
 
   Future<void> _onMicPressed(RtcViewmodel viewModel) async {
@@ -243,17 +336,7 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
-          IconButton(
-            onPressed: Hardware.instance.canSwitchSpeakerphone
-                ? _setSpeakerphoneOn
-                : null,
-            icon: Icon(
-              _speakerphoneOn ? Icons.speaker_phone : Icons.phone_android,
-              color: Colors.white.withValues(
-                  alpha: Hardware.instance.canSwitchSpeakerphone ? 1.0 : 0.5),
-            ),
-            iconSize: 30,
-          ),
+          _buildAudioOutputButton(),
           _buildCameraButton(viewModel),
           _buildMicButton(viewModel),
           IconButton(
@@ -355,6 +438,7 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
   @override
   void dispose() {
     participant.removeListener(_onChange);
+    _deviceSubscription?.cancel();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }

--- a/lib/rtc/widgets/rtc_controls.dart
+++ b/lib/rtc/widgets/rtc_controls.dart
@@ -33,7 +33,8 @@ class RtcControls extends StatefulWidget {
 class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
   CameraPosition position = CameraPosition.front;
 
-  bool _speakerphoneOn = Hardware.instance.preferSpeakerOutput;
+  bool _speakerphoneOn = true;
+  bool _userExplicitlySelectedEarpiece = false;
 
   PermissionStatus _micOsStatus = PermissionStatus.granted;
   PermissionStatus _cameraOsStatus = PermissionStatus.granted;
@@ -48,6 +49,8 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
   void initState() {
     super.initState();
     participant.addListener(_onChange);
+    // Set speaker immediately so audio is loud even before device list loads.
+    Hardware.instance.setSpeakerphoneOn(true);
     Hardware.instance.enumerateDevices().then(_loadDevices);
     _deviceSubscription =
         Hardware.instance.onDeviceChange.stream.listen(_loadDevices);
@@ -76,13 +79,35 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
     }
   }
 
-  void _loadDevices(List<MediaDevice> devices) async {
-    final outputs =
-        devices.where((d) => d.kind == 'audiooutput').toList();
-    if (mounted) {
+  void _loadDevices(List<MediaDevice> devices) {
+    final outputs = devices.where((d) => d.kind == 'audiooutput').toList();
+    final hadExternal =
+        _audioOutputDevices.any((d) => isExternalAudioDevice(d.label));
+    final hasExternal = outputs.any((d) => isExternalAudioDevice(d.label));
+
+    if (!mounted) return;
+    setState(() => _audioOutputDevices = outputs);
+
+    if (!hadExternal && hasExternal) {
+      // External device just connected (or was already there at first load).
+      // Always route to it regardless of any prior earpiece preference.
+      Hardware.instance.setSpeakerphoneOn(false);
       setState(() {
-        _audioOutputDevices = outputs;
+        _speakerphoneOn = false;
+        _selectedOutputDevice = null;
+        _userExplicitlySelectedEarpiece = false;
       });
+    } else if (hadExternal && !hasExternal) {
+      // External device disconnected.
+      if (!_userExplicitlySelectedEarpiece) {
+        // User was not on earpiece by choice → restore speaker.
+        Hardware.instance.setSpeakerphoneOn(true);
+        setState(() {
+          _speakerphoneOn = true;
+          _selectedOutputDevice = null;
+        });
+      }
+      // If user explicitly chose earpiece, leave them there.
     }
   }
 
@@ -179,12 +204,14 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
             setState(() {
               _speakerphoneOn = true;
               _selectedOutputDevice = null;
+              _userExplicitlySelectedEarpiece = false;
             });
           } else if (label.contains('earpiece')) {
             Hardware.instance.setSpeakerphoneOn(false);
             setState(() {
               _speakerphoneOn = false;
               _selectedOutputDevice = null;
+              _userExplicitlySelectedEarpiece = true;
             });
           } else {
             // Bluetooth / wired headset — desktop-only API; mobile routes automatically.
@@ -192,6 +219,7 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
               await Hardware.instance.selectAudioOutput(device);
               setState(() {
                 _selectedOutputDevice = device;
+                _userExplicitlySelectedEarpiece = false;
               });
             } catch (e) {
               if (kDebugMode) print('Could not select audio output: $e');


### PR DESCRIPTION
## Summary

This PR introduces audio output device selection support and improves audio routing behavior across RTC sessions.

## Changes

- Added `AudioOutputSheet` for selecting available audio output devices.
- Implemented detection and categorization of audio devices:
  - Bluetooth
  - Wired headphones
  - Speakerphone
  - Earpiece
- Added real-time audio device monitoring using `Hardware.instance.onDeviceChange`.
- Added visual indicators for the currently selected audio output device.
- Updated RTC controls to support audio output device selection and switching.
- Added dynamic audio output icons based on the active device.
- Refreshed available audio devices when the app resumes from the background.
- Set speakerphone as the default audio output on Android when joining a room.
- Added automatic routing to Bluetooth and wired devices when connected.
- Restored speakerphone when external devices are disconnected, unless the user explicitly selected the earpiece.