### PR TITLE
Fix iOS audio routing and device enumeration

### DIFF
--- a/lib/presentation/bottom_sheets/audio_output_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/audio_output_bottomsheet.dart
@@ -1,13 +1,57 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:livekit_client/livekit_client.dart';
 
 bool isExternalAudioDevice(String label) {
   final l = label.toLowerCase();
   return !l.contains('earpiece') &&
+      !l.contains('receiver') && // iOS earpiece label
       !l.contains('speakerphone') &&
       !l.contains('speaker');
+}
+
+// On iOS, enumerateDevices only returns currentRoute.outputs for audiooutput.
+// When overrideOutputAudioPort(.speaker) is active the route shows only Speaker,
+// hiding any connected BT device. BT HFP still appears in availableInputs (audioinput),
+// so we detect it there and inject the corresponding output entry.
+// We also always inject virtual Speaker + Earpiece entries.
+List<MediaDevice> augmentOutputsForIos(List<MediaDevice> allDevices) {
+  final audioOutputs = allDevices.where((d) => d.kind == 'audiooutput').toList();
+  if (defaultTargetPlatform != TargetPlatform.iOS) return audioOutputs;
+
+  final result = List<MediaDevice>.from(audioOutputs);
+
+  // Promote BT devices found in audioinput (availableInputs) to the output list.
+  // portType "BluetoothHFP/A2DP/LE" appears in availableInputs even when speaker is forced.
+  for (final input in allDevices.where((d) => d.kind == 'audioinput')) {
+    final g = (input.groupId ?? '').toLowerCase();
+    if (g.contains('bluetooth') &&
+        !result.any((o) => o.deviceId == input.deviceId)) {
+      result.add(MediaDevice(input.deviceId, input.label, 'audiooutput', input.groupId));
+    }
+  }
+
+  final hasExternal = result.any((d) => isExternalAudioDevice(d.label));
+
+  // Ensure Speaker is always present and at the top.
+  if (!result.any((d) => d.label.toLowerCase().contains('speaker'))) {
+    result.insert(0, const MediaDevice('Speaker', 'Speaker', 'audiooutput', 'Speaker'));
+  } else {
+    final idx = result.indexWhere((d) => d.label.toLowerCase().contains('speaker'));
+    if (idx > 0) result.insert(0, result.removeAt(idx));
+  }
+
+  // Show Earpiece only when no BT/wired is connected (iOS can't force earpiece over BT).
+  if (!hasExternal &&
+      !result.any((d) =>
+          d.label.toLowerCase().contains('receiver') ||
+          d.label.toLowerCase().contains('earpiece'))) {
+    result.add(const MediaDevice('Earpiece', 'Earpiece', 'audiooutput', 'Receiver'));
+  }
+
+  return result;
 }
 
 class AudioOutputSheet extends StatefulWidget {
@@ -41,8 +85,8 @@ class _AudioOutputSheetState extends State<AudioOutputSheet> {
   }
 
   void _onDeviceChange(List<MediaDevice> devices) {
-    final outputs = devices.where((d) => d.kind == 'audiooutput').toList();
-    if (mounted) setState(() => _devices = outputs);
+    final augmented = augmentOutputsForIos(devices);
+    if (mounted) setState(() => _devices = augmented);
   }
 
   @override
@@ -64,12 +108,15 @@ class _AudioOutputSheetState extends State<AudioOutputSheet> {
     final hasExternal = _devices.any((d) => isExternalAudioDevice(d.label));
     return hasExternal
         ? isExternalAudioDevice(device.label)
-        : l.contains('earpiece');
+        : l.contains('earpiece') || l.contains('receiver');
   }
 
-  IconData _iconForDevice(String label) {
-    final l = label.toLowerCase();
-    if (l.contains('bluetooth') ||
+  // groupId on iOS is AVAudioSession portType (e.g. "BluetoothHFP", "BluetoothA2DP").
+  IconData _iconForDevice(MediaDevice device) {
+    final l = device.label.toLowerCase();
+    final g = (device.groupId ?? '').toLowerCase();
+    if (g.contains('bluetooth') ||
+        l.contains('bluetooth') ||
         l.contains('airpods') ||
         l.contains('wireless')) {
       return Icons.bluetooth_audio;
@@ -78,7 +125,7 @@ class _AudioOutputSheetState extends State<AudioOutputSheet> {
     if (l.contains('speakerphone') || l.contains('speaker')) {
       return Icons.volume_up;
     }
-    if (l.contains('earpiece')) return Icons.hearing;
+    if (l.contains('earpiece') || l.contains('receiver')) return Icons.hearing;
     return Icons.volume_up;
   }
 
@@ -128,7 +175,7 @@ class _AudioOutputSheetState extends State<AudioOutputSheet> {
             else
               ..._devices.map(
                 (device) => _AudioDeviceOption(
-                  icon: _iconForDevice(device.label),
+                  icon: _iconForDevice(device),
                   label: device.label,
                   isSelected: _isSelected(device),
                   onTap: () => widget.onDeviceSelected(device),

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -30,6 +30,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../service/daakia_meeting_service.dart';
 import 'package:livekit_client/livekit_client.dart';
+import 'package:livekit_client/src/track/audio_management.dart'
+    show onConfigureNativeAudio, defaultNativeAudioConfigurationFunc, AudioTrackState;
+import 'package:livekit_client/src/support/native_audio.dart'
+    show NativeAudioConfiguration, AppleAudioCategory, AppleAudioCategoryOption, AppleAudioMode;
 import 'package:provider/provider.dart';
 import 'package:simple_pip_mode/simple_pip.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
@@ -107,6 +111,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
           statusBarBrightness: Brightness.dark,      // white icons on iOS
         ));
     WakelockPlus.enable();
+    _setupIosAudioConfig();
     if (lkPlatformIs(PlatformType.android)) {
       pip = SimplePip(onPipEntered: () {
         setState(() {
@@ -258,8 +263,42 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         .any((p) => p.track != null && !p.muted);
   }
 
+  // On iOS, override LiveKit's default audio config function so that when the user
+  // has chosen speaker output, we use overrideOutputAudioPort(.speaker) — applied by
+  // setting preferSpeakerOutput:true — instead of the defaultToSpeaker category option.
+  // defaultToSpeaker is only valid for PlayAndRecord; when audioTrackState=remoteOnly
+  // LiveKit picks Playback category, causing OSStatus error -50 with defaultToSpeaker.
+  // overrideOutputAudioPort(.speaker) works with any category and persists through
+  // LiveKit's automatic session reconfigurations.
+  void _setupIosAudioConfig() {
+    if (defaultTargetPlatform != TargetPlatform.iOS) return;
+    onConfigureNativeAudio = (AudioTrackState state) async {
+      // Only force speaker when user explicitly tapped "Speaker" (forceSpeakerOutput = true).
+      // At startup preferSpeakerOutput is true but forceSpeakerOutput is false, so iOS
+      // can auto-route to BT/wired if connected (videoChat + allowBluetooth handles it).
+      if (Hardware.instance.forceSpeakerOutput) {
+        if (state == AudioTrackState.none) return NativeAudioConfiguration.soloAmbient;
+        // Use PlayAndRecord so defaultToSpeaker (added by setSpeakerphoneOn forceSpeakerOutput)
+        // is valid, and preferSpeakerOutput calls overrideOutputAudioPort(.speaker) which
+        // forces the built-in loudspeaker even when BT is connected.
+        return NativeAudioConfiguration(
+          appleAudioCategory: AppleAudioCategory.playAndRecord,
+          appleAudioCategoryOptions: {
+            AppleAudioCategoryOption.allowBluetooth,
+            AppleAudioCategoryOption.allowBluetoothA2DP,
+            AppleAudioCategoryOption.allowAirPlay,
+          },
+          appleAudioMode: AppleAudioMode.videoChat,
+          preferSpeakerOutput: true,
+        );
+      }
+      return defaultNativeAudioConfigurationFunc(state);
+    };
+  }
+
   @override
   void dispose() {
+    onConfigureNativeAudio = defaultNativeAudioConfigurationFunc;
     _zoomController.removeListener(_onZoomChanged);
     _zoomController.dispose();
     super.dispose();

--- a/lib/rtc/widgets/rtc_controls.dart
+++ b/lib/rtc/widgets/rtc_controls.dart
@@ -80,10 +80,21 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
   }
 
   void _loadDevices(List<MediaDevice> devices) {
-    final outputs = devices.where((d) => d.kind == 'audiooutput').toList();
+    final rawOutputs = devices.where((d) => d.kind == 'audiooutput').toList();
     final hadExternal =
         _audioOutputDevices.any((d) => isExternalAudioDevice(d.label));
-    final hasExternal = outputs.any((d) => isExternalAudioDevice(d.label));
+
+    // On iOS, also check audioinput for BT devices: when overrideOutputAudioPort(.speaker)
+    // is active the current route shows only Speaker, but BT HFP still appears in
+    // availableInputs (audioinput kind) with portType containing "bluetooth".
+    final hasBtInput = defaultTargetPlatform == TargetPlatform.iOS &&
+        devices.any((d) =>
+            d.kind == 'audioinput' &&
+            (d.groupId ?? '').toLowerCase().contains('bluetooth'));
+    final hasExternal =
+        rawOutputs.any((d) => isExternalAudioDevice(d.label)) || hasBtInput;
+
+    final outputs = augmentOutputsForIos(devices);
 
     if (!mounted) return;
     setState(() => _audioOutputDevices = outputs);
@@ -154,13 +165,16 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
         .where((d) => isExternalAudioDevice(d.label))
         .firstOrNull;
     return external != null
-        ? _iconForDeviceLabel(external.label)
+        ? _iconForDeviceLabel(external.label, external.groupId)
         : Icons.hearing;
   }
 
-  IconData _iconForDeviceLabel(String label) {
+  // groupId on iOS is AVAudioSession portType (e.g. "BluetoothHFP", "BluetoothA2DP").
+  IconData _iconForDeviceLabel(String label, [String? groupId]) {
     final l = label.toLowerCase();
-    if (l.contains('bluetooth') ||
+    final g = (groupId ?? '').toLowerCase();
+    if (g.contains('bluetooth') ||
+        l.contains('bluetooth') ||
         l.contains('airpods') ||
         l.contains('wireless')) {
       return Icons.bluetooth_audio;
@@ -200,13 +214,13 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
           Navigator.pop(ctx);
           final label = device.label.toLowerCase();
           if (label.contains('speakerphone') || label.contains('speaker')) {
-            Hardware.instance.setSpeakerphoneOn(true);
+            Hardware.instance.setSpeakerphoneOn(true, forceSpeakerOutput: true);
             setState(() {
               _speakerphoneOn = true;
               _selectedOutputDevice = null;
               _userExplicitlySelectedEarpiece = false;
             });
-          } else if (label.contains('earpiece')) {
+          } else if (label.contains('earpiece') || label.contains('receiver')) {
             Hardware.instance.setSpeakerphoneOn(false);
             setState(() {
               _speakerphoneOn = false;
@@ -214,16 +228,16 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
               _userExplicitlySelectedEarpiece = true;
             });
           } else {
-            // Bluetooth / wired headset — desktop-only API; mobile routes automatically.
-            try {
-              await Hardware.instance.selectAudioOutput(device);
-              setState(() {
-                _selectedOutputDevice = device;
-                _userExplicitlySelectedEarpiece = false;
-              });
-            } catch (e) {
-              if (kDebugMode) print('Could not select audio output: $e');
-            }
+            // BT / wired headset.
+            // selectAudioOutput is desktop-only in LiveKit; on mobile, calling
+            // setSpeakerphoneOn(false) removes the speaker override and lets iOS/Android
+            // auto-route to the connected BT/wired device by OS priority.
+            Hardware.instance.setSpeakerphoneOn(false);
+            setState(() {
+              _speakerphoneOn = false;
+              _selectedOutputDevice = null;
+              _userExplicitlySelectedEarpiece = false;
+            });
           }
         },
       ),


### PR DESCRIPTION
## Summary

This PR improves iOS audio routing stability and enhances audio output device detection and selection across mobile platforms.

## Changes

- Updated iOS room audio configuration to use `preferSpeakerOutput` when speaker mode is forced.
- Improved audio routing stability during session reconfigurations on iOS.
- Added `augmentOutputsForIos` to detect and display Bluetooth audio devices even when hidden by iOS system routing.
- Ensured "Speaker" and "Earpiece" options are always available and correctly labeled on iOS.
- Improved handling of iOS-specific device labels such as "receiver".
- Updated RTC controls to correctly manage speakerphone toggling and device selection priority on mobile devices.
- Enhanced audio device identification logic using both device labels and group IDs.
- Improved Bluetooth and wired headset detection for more accurate device icons and routing behavior.