### PR TITLE
Fix/bug fixes

### DIFF
--- a/lib/presentation/pages/transcription_screen.dart
+++ b/lib/presentation/pages/transcription_screen.dart
@@ -28,6 +28,11 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> {
   // Latches to true the moment transcription becomes active; used to detect
   // the active→stopped transition and auto-close the screen for everyone.
   bool _wasTranscriptionActive = false;
+  // Guards the auto-close pop so it runs exactly once. Without this, a second
+  // viewmodel notification arriving during the pop animation re-triggers the
+  // close after this route is already off the top, bubbling the pop to
+  // RoomPage and firing its "close meeting?" back-press confirmation.
+  bool _isClosing = false;
 
 
   @override
@@ -65,9 +70,14 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> {
 
     final isActive = widget.viewModel.isTranscriptionLanguageSelected;
 
-    // Close the screen for everyone when transcription is stopped.
+    // Close the screen for everyone when transcription is stopped. Pop only
+    // once, and only while this screen is still the top route — otherwise the
+    // pop would bubble to RoomPage and trigger its close-meeting confirmation.
     if (_wasTranscriptionActive && !isActive) {
-      Navigator.of(context).maybePop();
+      if (!_isClosing && (ModalRoute.of(context)?.isCurrent ?? false)) {
+        _isClosing = true;
+        Navigator.of(context).pop();
+      }
       return;
     }
     if (isActive) _wasTranscriptionActive = true;

--- a/lib/presentation/pages/transcription_screen.dart
+++ b/lib/presentation/pages/transcription_screen.dart
@@ -1,4 +1,3 @@
-import 'package:daakia_vc_flutter_sdk/events/rtc_events.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/widgets/language_selection_bottom_sheet.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/widgets/loader.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/widgets/transcription_bubble.dart';
@@ -181,15 +180,30 @@ class _TranscriptionScreenState extends State<TranscriptionScreen> {
       "caption_${widget.viewModel.meetingDetails.meetingUid}_${DateTime.now().millisecondsSinceEpoch}",
     );
 
+    if (!mounted) return;
     setState(() => _isLoading = false);
 
+    // Show feedback locally: this screen is a fullscreen route pushed on top of
+    // RoomPage, so the room's notification overlay would render behind it and be
+    // invisible. Use this screen's own ScaffoldMessenger instead.
+    final messenger = ScaffoldMessenger.of(context);
     if (result.isSuccess) {
-      widget.viewModel.sendEvent(ShowTranscriptionDownload(
-        message: "File saved successfully!",
-        path: result.filePath,
-      ));
+      final path = result.filePath;
+      messenger.showSnackBar(
+        SnackBar(
+          content: const Text('File saved successfully!'),
+          action: path == null
+              ? null
+              : SnackBarAction(
+                  label: 'Open',
+                  onPressed: () => Utils.openMediaFile(path, context),
+                ),
+        ),
+      );
     } else {
-      widget.viewModel.sendMessageToUI("Failed to save file!");
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Failed to save file!')),
+      );
     }
   }
 

--- a/lib/rtc/widgets/participant.dart
+++ b/lib/rtc/widgets/participant.dart
@@ -153,6 +153,11 @@ abstract class _ParticipantWidgetState<T extends ParticipantWidget>
     final isAnnotationForThisShare = isScreenShare &&
         viewModel.isAnnotationActive &&
         viewModel.activeAnnotationSharerIdentity == widget.participant.identity;
+    // Someone (possibly a remote participant) has drawn on this share. The local
+    // sharer never sets isAnnotationActive — they can't draw — so we detect
+    // incoming strokes separately to un-blur and let them see the annotations.
+    final hasAnnotationsForThisShare = isScreenShare &&
+        viewModel.getAnnotationStrokes(widget.participant.identity).isNotEmpty;
 
     return Card(
       elevation: 10,
@@ -332,7 +337,8 @@ abstract class _ParticipantWidgetState<T extends ParticipantWidget>
             if (widget.isSpeaker &&
                 isScreenShare &&
                 widget.participant is LocalParticipant &&
-                !isAnnotationForThisShare)
+                !isAnnotationForThisShare &&
+                !hasAnnotationsForThisShare)
               Positioned.fill(
                 child: ClipRect(
                   child: BackdropFilter(

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -1521,6 +1521,7 @@ class RtcViewmodel extends ChangeNotifier {
 
   void configAutoRecording() {
     if (isHost() || isCoHost()) {
+      if (meetingDetails.features?.isRecordingAllowed() != true) return;
       if (meetingDetails.meetingBasicDetails?.meetingConfig != null) {
         var meetingConfig = meetingDetails.meetingBasicDetails?.meetingConfig!;
         if (meetingConfig?.recordingForceStopped != 1 &&

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2261,7 +2261,7 @@ class RtcViewmodel extends ChangeNotifier {
         isAudioModeEnable = data.audioPermission;
         isAudioPermissionEnable = !data.audioPermission;
         isChatAttachmentDownloadEnable = data.chatAttachmentDownloadEnabled;
-        isParticipantDrawerHidden = data.participantDrawer;
+        isParticipantDrawerHidden = !data.participantDrawer;
         isScreenShareEnable = data.screenSharePermissionGranted;
         isVideoModeEnable = data.videoPermission;
         isVideoPermissionEnable = !data.videoPermission;

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2708,7 +2708,6 @@ class RtcViewmodel extends ChangeNotifier {
     networkRequestHandler(
       apiCall: () => apiClient.allowParticipantAnnotation(meetingDetails.authorizationToken, selfIdentity, body),
       onSuccess: (data) {
-        if (data?.success != 1) return;
         sendPrivateAction(
           ActionModel(action: value ? MeetingActions.allowAnnotationPermission : MeetingActions.revokeAnnotationPermission),
           participantIdentity,


### PR DESCRIPTION
## Summary

This PR fixes participant drawer visibility handling, improves transcription download feedback, enhances annotation behavior, and addresses recording and navigation edge cases.

## Changes

- Fixed participant drawer visibility state assignment to correctly reflect the `participantDrawer` permission.
- Replaced global transcription download notifications with local snackbars for improved visibility on fullscreen transcription screens.
- Added an "Open" action to transcription download success notifications.
- Added `mounted` checks before `setState` calls to prevent async lifecycle issues.
- Removed redundant success validation from participant annotation permission handling.
- Fixed an issue where screen-share owners could not see incoming annotations drawn by other participants.
- Added annotation-aware rendering logic to preserve visibility of remote annotations on local screen shares.
- Prevented redundant navigation pops and accidental meeting exits from the transcription screen using route validation and an `_isClosing` guard.
- Added recording permission validation before executing auto-recording logic.
- Prevented hosts and co-hosts from automatically starting recordings when recording is disabled by meeting feature permissions.