### PR TITLE
Feat/save chat attachment locally

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />

--- a/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaVcFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaVcFlutterSdkPlugin.kt
@@ -1,11 +1,17 @@
 package io.daakia.daakia_vc_flutter_sdk
 
+import android.content.ContentValues
 import android.content.Context
+import android.os.Build
+import android.os.Environment
 import android.os.Handler
 import android.os.Looper
+import android.provider.MediaStore
+import androidx.annotation.RequiresApi
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import java.io.File
 
 class DaakiaVcFlutterSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
 
@@ -59,8 +65,52 @@ class DaakiaVcFlutterSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHandler 
                 DaakiaMeetingService.update(context, isMuted, showMuteButton)
                 result.success(null)
             }
+            "saveFileToDownloads" -> {
+                val sourcePath = call.argument<String>("sourcePath")
+                    ?: return result.error("INVALID_ARG", "sourcePath is required", null)
+                val fileName = call.argument<String>("fileName")
+                    ?: return result.error("INVALID_ARG", "fileName is required", null)
+                val mimeType = call.argument<String>("mimeType") ?: "*/*"
+                try {
+                    val savedPath = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        saveViaMediaStore(sourcePath, fileName, mimeType)
+                    } else {
+                        saveToLegacyDownloads(sourcePath, fileName)
+                    }
+                    result.success(savedPath)
+                } catch (e: Exception) {
+                    result.error("SAVE_ERROR", e.message, null)
+                }
+            }
             else -> result.notImplemented()
         }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun saveViaMediaStore(sourcePath: String, fileName: String, mimeType: String): String {
+        val resolver = context.contentResolver
+        val values = ContentValues().apply {
+            put(MediaStore.Downloads.DISPLAY_NAME, fileName)
+            put(MediaStore.Downloads.MIME_TYPE, mimeType)
+            put(MediaStore.Downloads.IS_PENDING, 1)
+        }
+        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+            ?: throw Exception("MediaStore insert failed for $fileName")
+        resolver.openOutputStream(uri)?.use { out ->
+            File(sourcePath).inputStream().use { it.copyTo(out) }
+        } ?: throw Exception("Could not open MediaStore output stream")
+        values.clear()
+        values.put(MediaStore.Downloads.IS_PENDING, 0)
+        resolver.update(uri, values, null, null)
+        return uri.toString()
+    }
+
+    private fun saveToLegacyDownloads(sourcePath: String, fileName: String): String {
+        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        dir.mkdirs()
+        val dest = File(dir, fileName)
+        File(sourcePath).copyTo(dest, overwrite = true)
+        return dest.absolutePath
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -7,23 +7,23 @@ PODS:
   - daakia_vc_flutter_sdk (4.4.0):
     - Flutter
   - datadog_flutter_plugin (0.0.1):
-    - DatadogCore (= 2.30.0)
-    - DatadogCrashReporting (= 2.30.0)
-    - DatadogInternal (= 2.30.0)
-    - DatadogLogs (= 2.30.0)
-    - DatadogRUM (= 2.30.0)
+    - DatadogCore (= 2.30.1)
+    - DatadogCrashReporting (= 2.30.1)
+    - DatadogInternal (= 2.30.1)
+    - DatadogLogs (= 2.30.1)
+    - DatadogRUM (= 2.30.1)
     - DictionaryCoder (= 1.2.0)
     - Flutter
-  - DatadogCore (2.30.0):
-    - DatadogInternal (= 2.30.0)
-  - DatadogCrashReporting (2.30.0):
-    - DatadogInternal (= 2.30.0)
+  - DatadogCore (2.30.1):
+    - DatadogInternal (= 2.30.1)
+  - DatadogCrashReporting (2.30.1):
+    - DatadogInternal (= 2.30.1)
     - PLCrashReporter (~> 1.12.0)
-  - DatadogInternal (2.30.0)
-  - DatadogLogs (2.30.0):
-    - DatadogInternal (= 2.30.0)
-  - DatadogRUM (2.30.0):
-    - DatadogInternal (= 2.30.0)
+  - DatadogInternal (2.30.1)
+  - DatadogLogs (2.30.1):
+    - DatadogInternal (= 2.30.1)
+  - DatadogRUM (2.30.1):
+    - DatadogInternal (= 2.30.1)
   - device_info_plus (0.0.1):
     - Flutter
   - DictionaryCoder (1.2.0)
@@ -182,12 +182,12 @@ SPEC CHECKSUMS:
   audioplayers_darwin: 4f9ca89d92d3d21cec7ec580e78ca888e5fb68bd
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   daakia_vc_flutter_sdk: b8382a2729ab1d78593251a24a0954c40ab944b1
-  datadog_flutter_plugin: 52c9877fbf3feae699a36868b32ea4f6ca979e37
-  DatadogCore: 5c01290a3b60b27bf49aa958f2e339c738364d9e
-  DatadogCrashReporting: 11286d48ab61baeb2b41b945c7c0d4ef23db317d
-  DatadogInternal: 7aeb48e254178a0c462c3953dc0a8a8d64499a93
-  DatadogLogs: 4324739de62a6059e07d70bf6ceceed78764edeb
-  DatadogRUM: f36949a38285f3b240a7be577d425f8518e087d4
+  datadog_flutter_plugin: 8cbbf0d89820bc9db1fa48e02bb87ee92d55d59c
+  DatadogCore: c09c6b3345d200ad8df6b8424562afc4c274d85e
+  DatadogCrashReporting: 19c67670fe9ee01cc4cbc3c859d6c69dc6344e9e
+  DatadogInternal: a712490b2c285095d748ccb437a9a630df949d7f
+  DatadogLogs: 084f7974d6dbe053b5fbabc07a245a700c1514f7
+  DatadogRUM: c9356f806db3599386f854bdb53494216600d2ae
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   DictionaryCoder: f7115fcd074c8301e91f2eb862da1ea7d0385e61
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
@@ -212,6 +212,6 @@ SPEC CHECKSUMS:
   WebRTC-SDK: ab9b5319e458c2bfebdc92b3600740da35d5630d
   webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
 
-PODFILE CHECKSUM: 1959d098c91d8a792531a723c4a9d7e9f6a01e38
+PODFILE CHECKSUM: e63ed792e7a9cf4bd9cd1d26d173e459815f209f
 
 COCOAPODS: 1.16.2

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -59,5 +59,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/screen/configuration_screen.dart
+++ b/example/lib/screen/configuration_screen.dart
@@ -22,6 +22,7 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
   bool _skipPreJoinPage = false;
   bool _enableMicrophoneByDefault = false;
   bool _enableCameraByDefault = false;
+  bool _saveAttachmentToDownloads = false;
   final TextEditingController _configNameController = TextEditingController();
 
   void _addMetadataField() {
@@ -78,6 +79,7 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
       skipPreJoinPage: _skipPreJoinPage,
       enableMicrophoneByDefault: _enableMicrophoneByDefault,
       enableCameraByDefault: _enableCameraByDefault,
+      saveAttachmentToDownloads: _saveAttachmentToDownloads,
     );
   }
 
@@ -110,6 +112,7 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
       _skipPreJoinPage = config.skipPreJoinPage == true;
       _enableMicrophoneByDefault = config.enableMicrophoneByDefault == true;
       _enableCameraByDefault = config.enableCameraByDefault == true;
+      _saveAttachmentToDownloads = config.saveAttachmentToDownloads == true;
     }
   }
 
@@ -232,6 +235,18 @@ class _ConfigurationScreenState extends State<ConfigurationScreen> {
                       onChanged: (value) {
                         setState(() {
                           _enableCameraByDefault = value;
+                        });
+                      },
+                    ),
+                    SwitchListTile(
+                      title: const Text("Save Attachments to Downloads"),
+                      subtitle: const Text(
+                        "Save received chat attachments to the downloads folder instead of temp",
+                      ),
+                      value: _saveAttachmentToDownloads,
+                      onChanged: (value) {
+                        setState(() {
+                          _saveAttachmentToDownloads = value;
                         });
                       },
                     ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -204,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: datadog_flutter_plugin
-      sha256: "9b04852147a0483e6cabf001b432aa7404bc9d364da73532c7c834b9a98eec28"
+      sha256: cb5c1f8012abc42a5499011cf8a4c6b710c5fb071957f297ad5cc1c1d5a32b35
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.1"
+    version: "2.16.1"
   dbus:
     dependency: transitive
     description:

--- a/ios/Classes/DaakiaVcFlutterSdkPlugin.swift
+++ b/ios/Classes/DaakiaVcFlutterSdkPlugin.swift
@@ -31,11 +31,40 @@ public class DaakiaVcFlutterSdkPlugin: NSObject, FlutterPlugin {
             // iOS keeps the audio session alive regardless of mute state — no-op.
             result(nil)
         case "saveFileToDownloads":
-            // iOS saves directly to the app Documents directory in Dart — no native step needed.
-            result(nil)
+            guard let args = call.arguments as? [String: Any],
+                  let sourcePath = args["sourcePath"] as? String,
+                  let fileName = args["fileName"] as? String else {
+                result(FlutterError(code: "INVALID_ARG", message: "sourcePath and fileName are required", details: nil))
+                return
+            }
+            do {
+                let savedPath = try saveFileToDownloads(sourcePath: sourcePath, fileName: fileName)
+                result(savedPath)
+            } catch {
+                result(FlutterError(code: "SAVE_ERROR", message: error.localizedDescription, details: nil))
+            }
         default:
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    // Copies a file into the app's Documents/Downloads directory (the only
+    // writable persistent location available within the iOS sandbox).
+    // Files here are visible in Files > On My iPhone > [App Name] > Downloads
+    // when the host app sets UIFileSharingEnabled = YES in its Info.plist.
+    private func saveFileToDownloads(sourcePath: String, fileName: String) throws -> String {
+        let fileManager = FileManager.default
+        let sourceURL = URL(fileURLWithPath: sourcePath)
+        let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let targetDir = documentsURL.appendingPathComponent("Downloads", isDirectory: true)
+
+        try fileManager.createDirectory(at: targetDir, withIntermediateDirectories: true, attributes: nil)
+        let destinationURL = targetDir.appendingPathComponent(fileName)
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+        try fileManager.copyItem(at: sourceURL, to: destinationURL)
+        return destinationURL.path
     }
 
     // Activates the audio session. Returns true on success, false if still interrupted.

--- a/ios/Classes/DaakiaVcFlutterSdkPlugin.swift
+++ b/ios/Classes/DaakiaVcFlutterSdkPlugin.swift
@@ -30,6 +30,9 @@ public class DaakiaVcFlutterSdkPlugin: NSObject, FlutterPlugin {
         case "updateMuteState":
             // iOS keeps the audio session alive regardless of mute state — no-op.
             result(nil)
+        case "saveFileToDownloads":
+            // iOS saves directly to the app Documents directory in Dart — no native step needed.
+            result(nil)
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/lib/model/daakia_meeting_configuration.dart
+++ b/lib/model/daakia_meeting_configuration.dart
@@ -76,6 +76,13 @@ class DaakiaMeetingConfiguration {
   /// All fields are optional and can be left null to use default behavior.
   final VCConfig? vcConfig;
 
+  /// When true, downloaded chat attachments are saved to the device's
+  /// downloads folder (or the app documents directory on iOS) instead of a
+  /// temporary directory, so users can access them after the meeting ends.
+  ///
+  /// Defaults to `false` when not provided.
+  final bool? saveAttachmentToDownloads;
+
   const DaakiaMeetingConfiguration({
     this.metadata,
     this.participantNameConfig,
@@ -83,5 +90,6 @@ class DaakiaMeetingConfiguration {
     this.enableMicrophoneByDefault,
     this.enableCameraByDefault,
     this.vcConfig,
+    this.saveAttachmentToDownloads,
   });
 }

--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -775,7 +775,7 @@ class _PreJoinState extends State<PreJoinScreen> {
         final navigator = Navigator.of(this.context);
         await navigator.push<void>(
           MaterialPageRoute(
-              builder: (_) => RoomPage(room, listener, meetingDetails, fastConnection: true)),
+              builder: (_) => RoomPage(room, listener, meetingDetails, fastConnection: true, saveAttachmentToDownloads: widget.configuration?.saveAttachmentToDownloads == true)),
         );
         if (mounted && navigator.canPop()) {
           navigator.pop();

--- a/lib/presentation/widgets/file_preview.dart
+++ b/lib/presentation/widgets/file_preview.dart
@@ -162,11 +162,11 @@ class _FilePreviewWidgetState extends State<FilePreviewWidget> {
 
             setState(() => _progress = null);
 
-            if (widget.saveAttachmentToDownloads && !widget.isSender && Platform.isAndroid) {
-              await DownloadUtils.saveToPublicDownloads(
+            if (widget.saveAttachmentToDownloads && !widget.isSender) {
+              await DownloadUtils.saveToDownloads(
                 sourcePath: filePath,
                 fileName: fileName,
-                mimeType: mimeType ?? '*/*',
+                mimeType: mimeType,
               );
             }
 
@@ -237,12 +237,6 @@ class _FilePreviewWidgetState extends State<FilePreviewWidget> {
   }
 
   Future<String> _resolveFilePath(String fileName) async {
-    if (widget.saveAttachmentToDownloads && !widget.isSender && Platform.isIOS) {
-      // iOS: save directly to app Documents directory (accessible via Files app).
-      // Android copies to public Downloads after download via DownloadUtils.
-      final dir = await getApplicationDocumentsDirectory();
-      return '${dir.path}/$fileName';
-    }
     final tempDir = await getTemporaryDirectory();
     return '${tempDir.path}/$fileName';
   }

--- a/lib/presentation/widgets/file_preview.dart
+++ b/lib/presentation/widgets/file_preview.dart
@@ -15,8 +15,16 @@ import 'package:path_provider/path_provider.dart';
 class FilePreviewWidget extends StatefulWidget {
   final String fileUrl;
   final bool isChatAttachmentDownloadEnable;
+  final bool isSender;
+  final bool saveAttachmentToDownloads;
 
-  const FilePreviewWidget({super.key, required this.fileUrl, required this.isChatAttachmentDownloadEnable});
+  const FilePreviewWidget({
+    super.key,
+    required this.fileUrl,
+    required this.isChatAttachmentDownloadEnable,
+    this.isSender = false,
+    this.saveAttachmentToDownloads = false,
+  });
 
   @override
   State<FilePreviewWidget> createState() => _FilePreviewWidgetState();
@@ -130,8 +138,7 @@ class _FilePreviewWidgetState extends State<FilePreviewWidget> {
             MaterialPageRoute(builder: (_) => WebPreview(url: widget.fileUrl)),
           );
         } else {
-          final tempDir = await getTemporaryDirectory();
-          final filePath = '${tempDir.path}/${widget.fileUrl.split('/').last}';
+          final filePath = await _resolveFilePath(widget.fileUrl.split('/').last);
 
           if (File(filePath).existsSync()) {
             try {
@@ -217,6 +224,16 @@ class _FilePreviewWidgetState extends State<FilePreviewWidget> {
         ],
       ),
     );
+  }
+
+  Future<String> _resolveFilePath(String fileName) async {
+    if (widget.saveAttachmentToDownloads && !widget.isSender) {
+      final downloadsDir = await getDownloadsDirectory();
+      final baseDir = downloadsDir ?? await getApplicationDocumentsDirectory();
+      return '${baseDir.path}/$fileName';
+    }
+    final tempDir = await getTemporaryDirectory();
+    return '${tempDir.path}/$fileName';
   }
 
   Future<void> _downloadFile(String url, String filePath) async {

--- a/lib/presentation/widgets/file_preview.dart
+++ b/lib/presentation/widgets/file_preview.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 import 'dart:io';
 
 import 'package:daakia_vc_flutter_sdk/presentation/screens/web_preview.dart';
+import 'package:daakia_vc_flutter_sdk/utils/download_utils.dart';
 import 'package:daakia_vc_flutter_sdk/utils/utils.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/cupertino.dart';
@@ -138,7 +139,8 @@ class _FilePreviewWidgetState extends State<FilePreviewWidget> {
             MaterialPageRoute(builder: (_) => WebPreview(url: widget.fileUrl)),
           );
         } else {
-          final filePath = await _resolveFilePath(widget.fileUrl.split('/').last);
+          final fileName = Uri.decodeFull(widget.fileUrl.split('/').last);
+          final filePath = await _resolveFilePath(fileName);
 
           if (File(filePath).existsSync()) {
             try {
@@ -159,6 +161,14 @@ class _FilePreviewWidgetState extends State<FilePreviewWidget> {
             await _downloadFile(widget.fileUrl, filePath);
 
             setState(() => _progress = null);
+
+            if (widget.saveAttachmentToDownloads && !widget.isSender && Platform.isAndroid) {
+              await DownloadUtils.saveToPublicDownloads(
+                sourcePath: filePath,
+                fileName: fileName,
+                mimeType: mimeType ?? '*/*',
+              );
+            }
 
             try {
               final result = await OpenFile.open(filePath);
@@ -227,10 +237,11 @@ class _FilePreviewWidgetState extends State<FilePreviewWidget> {
   }
 
   Future<String> _resolveFilePath(String fileName) async {
-    if (widget.saveAttachmentToDownloads && !widget.isSender) {
-      final downloadsDir = await getDownloadsDirectory();
-      final baseDir = downloadsDir ?? await getApplicationDocumentsDirectory();
-      return '${baseDir.path}/$fileName';
+    if (widget.saveAttachmentToDownloads && !widget.isSender && Platform.isIOS) {
+      // iOS: save directly to app Documents directory (accessible via Files app).
+      // Android copies to public Downloads after download via DownloadUtils.
+      final dir = await getApplicationDocumentsDirectory();
+      return '${dir.path}/$fileName';
     }
     final tempDir = await getTemporaryDirectory();
     return '${tempDir.path}/$fileName';

--- a/lib/presentation/widgets/message_bubble.dart
+++ b/lib/presentation/widgets/message_bubble.dart
@@ -198,8 +198,9 @@ class _MessageBubbleState extends State<MessageBubble> {
                                 color: Colors.transparent,
                                 child: FilePreviewWidget(
                                   fileUrl: url,
-                                  isChatAttachmentDownloadEnable: widget
-                                      .viewModel.isChatAttachmentDownloadEnable,
+                                  isChatAttachmentDownloadEnable: widget.viewModel.isChatAttachmentDownloadEnable,
+                                  isSender: isSender,
+                                  saveAttachmentToDownloads: widget.viewModel.saveAttachmentToDownloads,
                                 ),
                               ),
                             ),

--- a/lib/rtc/method_channels/daakia_pip.dart
+++ b/lib/rtc/method_channels/daakia_pip.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 class DaakiaPiP {
@@ -17,13 +18,17 @@ class DaakiaPiP {
     _methodChannel.invokeMethod("createPiP", {
       "name": name,
       "avatar": avatar ?? "",
-    });
+    }).catchError((e) => debugPrint('[DaakiaPiP] createPiP error: $e'));
   }
 
   /// Dispose PiP view
   static void disposePiP() async {
     if (!Platform.isIOS) return;
 
-    await _methodChannel.invokeMethod("disposePiP");
+    try {
+      await _methodChannel.invokeMethod("disposePiP");
+    } catch (e) {
+      debugPrint('[DaakiaPiP] disposePiP error: $e');
+    }
   }
 }

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -57,12 +57,14 @@ class RoomPage extends StatefulWidget {
   final EventsListener<RoomEvent> listener;
   final MeetingDetails meetingDetails;
   final bool fastConnection;
+  final bool saveAttachmentToDownloads;
 
   const RoomPage(
     this.room,
     this.listener,
     this.meetingDetails, {
     this.fastConnection = false,
+    this.saveAttachmentToDownloads = false,
     super.key,
   });
 
@@ -1222,6 +1224,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         key: _livekitProviderKey,
         room: widget.room,
         meetingDetails: widget.meetingDetails,
+        saveAttachmentToDownloads: widget.saveAttachmentToDownloads,
         child: MaterialApp(
           navigatorKey: _innerNavigatorKey,
           debugShowCheckedModeBanner: false,

--- a/lib/utils/download_utils.dart
+++ b/lib/utils/download_utils.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+class DownloadUtils {
+  static const _channel = MethodChannel('io.daakia/meeting_service');
+
+  /// Copies [sourcePath] into the public Downloads folder (Android only).
+  /// On API < 29 this requests WRITE_EXTERNAL_STORAGE first; on API 29+
+  /// it uses MediaStore.Downloads (no permission needed).
+  /// Returns true on success, false if the permission was denied or a
+  /// non-fatal error occurred.
+  static Future<bool> saveToPublicDownloads({
+    required String sourcePath,
+    required String fileName,
+    required String mimeType,
+  }) async {
+    if (!Platform.isAndroid) return false;
+
+    try {
+      final sdkInt = (await DeviceInfoPlugin().androidInfo).version.sdkInt;
+      if (sdkInt < 29) {
+        final status = await Permission.storage.request();
+        if (!status.isGranted) {
+          debugPrint('[DownloadUtils] WRITE_EXTERNAL_STORAGE denied');
+          return false;
+        }
+      }
+
+      debugPrint('[DownloadUtils] saveToPublicDownloads: sourcePath=$sourcePath, fileName=$fileName, mimeType=$mimeType');
+      final result = await _channel.invokeMethod<String>('saveFileToDownloads', {
+        'sourcePath': sourcePath,
+        'fileName': fileName,
+        'mimeType': mimeType,
+      });
+      debugPrint('[DownloadUtils] saved to: $result');
+      return true;
+    } catch (e) {
+      debugPrint('[DownloadUtils] error: $e');
+      return false;
+    }
+  }
+}

--- a/lib/utils/download_utils.dart
+++ b/lib/utils/download_utils.dart
@@ -8,29 +8,37 @@ import 'package:permission_handler/permission_handler.dart';
 class DownloadUtils {
   static const _channel = MethodChannel('io.daakia/meeting_service');
 
-  /// Copies [sourcePath] into the public Downloads folder (Android only).
-  /// On API < 29 this requests WRITE_EXTERNAL_STORAGE first; on API 29+
-  /// it uses MediaStore.Downloads (no permission needed).
-  /// Returns true on success, false if the permission was denied or a
-  /// non-fatal error occurred.
-  static Future<bool> saveToPublicDownloads({
+  /// Copies [sourcePath] into the platform downloads folder.
+  ///
+  /// Android: public Downloads directory. API < 29 requests
+  /// WRITE_EXTERNAL_STORAGE first; API 29+ uses MediaStore (no permission).
+  ///
+  /// iOS: iCloud Drive Downloads on iOS 16+ when iCloud Drive is available,
+  /// otherwise a "Downloads" subfolder in the app Documents directory
+  /// (visible in Files > On My iPhone > [App Name] when the host app sets
+  /// UIFileSharingEnabled = YES in its Info.plist).
+  ///
+  /// Returns true on success, false on permission denial or non-fatal error.
+  static Future<bool> saveToDownloads({
     required String sourcePath,
     required String fileName,
     required String mimeType,
   }) async {
-    if (!Platform.isAndroid) return false;
+    if (!Platform.isAndroid && !Platform.isIOS) return false;
 
     try {
-      final sdkInt = (await DeviceInfoPlugin().androidInfo).version.sdkInt;
-      if (sdkInt < 29) {
-        final status = await Permission.storage.request();
-        if (!status.isGranted) {
-          debugPrint('[DownloadUtils] WRITE_EXTERNAL_STORAGE denied');
-          return false;
+      if (Platform.isAndroid) {
+        final sdkInt = (await DeviceInfoPlugin().androidInfo).version.sdkInt;
+        if (sdkInt < 29) {
+          final status = await Permission.storage.request();
+          if (!status.isGranted) {
+            debugPrint('[DownloadUtils] WRITE_EXTERNAL_STORAGE denied');
+            return false;
+          }
         }
       }
 
-      debugPrint('[DownloadUtils] saveToPublicDownloads: sourcePath=$sourcePath, fileName=$fileName, mimeType=$mimeType');
+      debugPrint('[DownloadUtils] saveToDownloads: sourcePath=$sourcePath, fileName=$fileName, mimeType=$mimeType');
       final result = await _channel.invokeMethod<String>('saveFileToDownloads', {
         'sourcePath': sourcePath,
         'fileName': fileName,

--- a/lib/viewmodel/rtc_provider.dart
+++ b/lib/viewmodel/rtc_provider.dart
@@ -8,8 +8,15 @@ class RtcProvider extends StatefulWidget {
   final Room room;
   final MeetingDetails meetingDetails;
   final Widget child;
+  final bool saveAttachmentToDownloads;
 
-  const RtcProvider({required this.room, required this.meetingDetails, required this.child, super.key});
+  const RtcProvider({
+    required this.room,
+    required this.meetingDetails,
+    required this.child,
+    this.saveAttachmentToDownloads = false,
+    super.key,
+  });
 
   @override
   RtcProviderState createState() => RtcProviderState();
@@ -21,7 +28,7 @@ class RtcProviderState extends State<RtcProvider> {
   @override
   void initState() {
     super.initState();
-    viewModel = RtcViewmodel(widget.room, widget.meetingDetails); // Initialize the view model
+    viewModel = RtcViewmodel(widget.room, widget.meetingDetails, saveAttachmentToDownloads: widget.saveAttachmentToDownloads);
   }
 
   @override

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -126,7 +126,9 @@ class RtcViewmodel extends ChangeNotifier {
     notifyListeners();
   }
 
-  RtcViewmodel(this.room, this.meetingDetails);
+  final bool saveAttachmentToDownloads;
+
+  RtcViewmodel(this.room, this.meetingDetails, {this.saveAttachmentToDownloads = false});
 
   List<RemoteActivityData> getMessageList() {
     return _messageList;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   webview_flutter_android: ^4.10.1
   webview_flutter_wkwebview: ^3.23.0
   audioplayers: ^6.5.1
-  datadog_flutter_plugin: ^2.13.1
+  datadog_flutter_plugin: ^2.16.1
   connectivity_plus: ^7.0.0
   device_info_plus: ^12.2.0
 


### PR DESCRIPTION
## Summary

This PR adds configurable attachment download persistence, native downloads support for Android and iOS, and improves file handling and PiP error resilience.

## Changes

- Added `saveAttachmentToDownloads` to `DaakiaMeetingConfiguration` with a default value of `false`.
- Added support for saving chat attachments to persistent storage instead of temporary directories when enabled.
- Propagated `saveAttachmentToDownloads` through `PreJoinScreen`, `RoomPage`, `RtcProvider`, and `RtcViewmodel`.
- Updated attachment handling logic to differentiate between sent and received files during downloads.
- Added native Android downloads support using `MediaStore` and legacy storage APIs via `DownloadUtils`.
- Added Android storage permission support for devices running Android 9 (API 28) and below.
- Implemented native iOS support for saving files to a persistent Downloads directory within the app's Documents folder.
- Unified Android and iOS download handling through `DownloadUtils.saveToDownloads`.
- Improved filename extraction using `Uri.decodeFull`.
- Added configuration support and UI toggle for attachment download behavior in the example application.
- Enabled iOS file sharing and in-place document opening through `Info.plist` configuration.
- Added error handling and logging for PiP method channel operations to prevent unhandled exceptions during PiP lifecycle events.