### PR TITLE
Release/v4.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## v4.5.1 – (2026-06)
+
+### 🚀 New Features
+- **Notification Permission Dialog (Android)** — Customizable dialog enforcing notification permission before starting screen sharing.
+
+### 🧩 Improvements
+- Debounced participant list sorting to reduce main-thread churn.
+
+### 🐞 Bug Fixes
+- Fixed screen-share crash by setting `singleTask` launch mode and adding a guarded auto-stop for local screen sharing.
+- Fixed concurrent screen-share actions causing ANRs.
+- Fixed ANRs during app resume by refactoring `restartIfActive`.
+- Fixed cleanup and navigation on all room disconnect events.
+- Added missing microphone/camera foreground service types to `DaakiaMeetingService`.
+- Fixed screen-share service availability handling on Android 14+.
+- Removed unnecessary `mounted` checks in `more_option_bottomsheet.dart`.
+
 ## v4.5.0 – (2026-06)
 
 > **Major release.** Requires **Flutter 3.22+ (Dart SDK ^3.8.0)**. After upgrading, run `flutter clean && flutter pub get` to avoid conflicts from major dependency updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,11 @@
 - Debounced participant list sorting to reduce main-thread churn.
 
 ### 🐞 Bug Fixes
-- Fixed screen-share crash by setting `singleTask` launch mode and adding a guarded auto-stop for local screen sharing.
 - Fixed concurrent screen-share actions causing ANRs.
 - Fixed ANRs during app resume by refactoring `restartIfActive`.
 - Fixed cleanup and navigation on all room disconnect events.
 - Added missing microphone/camera foreground service types to `DaakiaMeetingService`.
 - Fixed screen-share service availability handling on Android 14+.
-- Removed unnecessary `mounted` checks in `more_option_bottomsheet.dart`.
 
 ## v4.5.0 – (2026-06)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This SDK provides a simple and efficient way to add video conferencing features 
 ✅ **Android**  | ✅ **iOS**
 
 ## Latest Release
-**v4.5.0** - See [CHANGELOG.md](CHANGELOG.md) for detailed release notes and what's new.
+**v4.5.1** - See [CHANGELOG.md](CHANGELOG.md) for detailed release notes and what's new.
 
 # How to use
 
@@ -21,7 +21,7 @@ add ``daakia_vc_flutter_sdk:`` to your ``pubspec.yaml`` dependencies then run ``
 
 ```yaml
   dependencies:
-    daakia_vc_flutter_sdk: ^4.5.0
+    daakia_vc_flutter_sdk: ^4.5.1
 ```
 
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application>
@@ -11,7 +13,7 @@
             android:name="io.daakia.daakia_vc_flutter_sdk.DaakiaMeetingService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="mediaPlayback|mediaProjection" />
+            android:foregroundServiceType="mediaPlayback|mediaProjection|microphone|camera" />
     </application>
 
 </manifest>

--- a/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaMeetingService.kt
+++ b/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaMeetingService.kt
@@ -80,6 +80,35 @@ class DaakiaMeetingService : Service() {
         super.onDestroy()
     }
 
+    // Base FGS type mask used for the meeting. Each startForeground() call
+    // replaces the previous mask, so every call must include all active types.
+    //
+    // FOREGROUND_SERVICE_TYPE_MICROPHONE requires API 30, the manifest permission
+    // FOREGROUND_SERVICE_MICROPHONE, AND the RECORD_AUDIO runtime permission to
+    // already be granted. Without the runtime grant Android 12+ (targetSdk 32+)
+    // throws SecurityException — same crash pattern as the old camera type crash.
+    // So we only include it when the permission is actually held.
+    private val baseFgsType: Int
+        get() {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return 0
+            var type = ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                // Only include microphone/camera types when the runtime permission is
+                // already granted. Including a type without its runtime grant throws
+                // SecurityException on Android 12+ (targetSdk 32+) — same crash
+                // pattern as the old IsolateHolderService camera type crash in v4.4.1.
+                if (checkSelfPermission(android.Manifest.permission.RECORD_AUDIO)
+                        == android.content.pm.PackageManager.PERMISSION_GRANTED) {
+                    type = type or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                }
+                if (checkSelfPermission(android.Manifest.permission.CAMERA)
+                        == android.content.pm.PackageManager.PERMISSION_GRANTED) {
+                    type = type or ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
+                }
+            }
+            return type
+        }
+
     /** Adds mediaProjection type to the running FGS. Must be called on the main thread,
      *  immediately after the user grants screen capture permission. */
     fun addMediaProjectionType() {
@@ -89,8 +118,7 @@ class DaakiaMeetingService : Service() {
                     this,
                     NOTIFICATION_ID,
                     buildNotification(),
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK or
-                            ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
+                    baseFgsType or ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
                 )
             } catch (e: Exception) {
                 Log.w(TAG, "addMediaProjectionType failed: $e")
@@ -106,7 +134,7 @@ class DaakiaMeetingService : Service() {
                     this,
                     NOTIFICATION_ID,
                     buildNotification(),
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                    baseFgsType
                 )
             } catch (e: Exception) {
                 Log.w(TAG, "removeMediaProjectionType failed: $e")
@@ -157,15 +185,7 @@ class DaakiaMeetingService : Service() {
         createNotificationChannel()
         val notification = buildNotification()
         try {
-            ServiceCompat.startForeground(
-                this,
-                NOTIFICATION_ID,
-                notification,
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
-                else
-                    0
-            )
+            ServiceCompat.startForeground(this, NOTIFICATION_ID, notification, baseFgsType)
         } catch (e: Exception) {
             Log.w(TAG, "startForeground failed, running without foreground promotion: $e")
         }

--- a/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaVcFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/io/daakia/daakia_vc_flutter_sdk/DaakiaVcFlutterSdkPlugin.kt
@@ -52,7 +52,12 @@ class DaakiaVcFlutterSdkPlugin : FlutterPlugin, MethodChannel.MethodCallHandler 
                 result.success(null)
             }
             "startScreenShareService" -> {
-                DaakiaMeetingService.instance?.addMediaProjectionType()
+                val svc = DaakiaMeetingService.instance
+                if (svc == null) {
+                    result.error("SERVICE_NOT_RUNNING", "DaakiaMeetingService is not running", null)
+                    return
+                }
+                svc.addMediaProjectionType()
                 result.success(null)
             }
             "stopScreenShareService" -> {

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
 
 
     <application
-        android:label="example"
+        android:label="DaakiaVC Demo"
         android:name="${applicationName}"
         android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher">

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:taskAffinity=""
             android:theme="@style/LaunchTheme"
             android:supportsPictureInPicture="true"

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Example</string>
+	<string>DaakiaVC Demo</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -183,7 +183,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.4.1"
+    version: "4.5.0"
   dart_jsonwebtoken:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 4.4.1+5
+version: 4.5.0+6
 
 environment:
   sdk: ^3.5.3

--- a/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
@@ -310,7 +310,14 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
         // meeting). Calling addMediaProjectionType() on the main thread is
         // synchronous, so the FGS type is registered before getDisplayMedia
         // is called — no race condition on rapid stop/start.
-        await DaakiaMeetingService.startScreenShare();
+        final ok = await DaakiaMeetingService.startScreenShare();
+        if (!ok) {
+          // Service was killed by the OS (common on Samsung with aggressive
+          // battery optimisation). Without the FGS mediaProjection type,
+          // getDisplayMedia throws SecurityException on Android 14+.
+          if (mounted) viewModel.sendMessageToUI("Screen share unavailable. Please rejoin the meeting and try again.");
+          return;
+        }
       } else {
         requestBackgroundPermission([bool isRetry = false]) async {
           try {
@@ -367,6 +374,7 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
       return;
     }
 
+    if (!mounted) return;
     await participant?.setScreenShareEnabled(true, captureScreenAudio: true);
   }
 

--- a/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
@@ -16,6 +16,7 @@ import '../../utils/meeting_actions.dart';
 import '../../utils/utils.dart';
 import '../../viewmodel/rtc_viewmodel.dart';
 import '../dialog/emoji_dialog.dart';
+import '../dialog/notification_permission_dialog.dart';
 import '../pages/all_participant_page.dart';
 import '../pages/permission_request_page.dart';
 import '../pages/transcription_screen.dart';
@@ -315,6 +316,27 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
 
     if (lkPlatformIs(PlatformType.android)) {
       // Android specific
+      // Screen share is the highest-risk action for OEM background throttling
+      // without a visible foreground-service notification (root caused an ANR
+      // on MIUI). Unlike the soft reminder at meeting join, this is a hard
+      // gate: screen share will not start without notification permission.
+      // Shown before the system capture-permission dialog so the two don't
+      // stack; the user must grant it via Settings and retry.
+      if (!await DaakiaMeetingService.hasNotificationPermission()) {
+        if (mounted) {
+          await showNotificationPermissionDialog(
+            context,
+            title: 'Notification Permission Required',
+            message:
+                'Screen sharing needs notification permission to keep running reliably in the background. Enable it in Settings, then try again.',
+            dismissLabel: 'Cancel',
+          );
+        }
+        viewModel.sendMessageToUI(
+            'Screen sharing requires notification permission. Please enable it and try again.');
+        return;
+      }
+
       bool hasCapturePermission = await Helper.requestCapturePermission();
       if (!hasCapturePermission) {
         return;

--- a/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
@@ -315,7 +315,7 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
           // Service was killed by the OS (common on Samsung with aggressive
           // battery optimisation). Without the FGS mediaProjection type,
           // getDisplayMedia throws SecurityException on Android 14+.
-          if (mounted) viewModel.sendMessageToUI("Screen share unavailable. Please rejoin the meeting and try again.");
+          viewModel.sendMessageToUI("Screen share unavailable. Please rejoin the meeting and try again.");
           return;
         }
       } else {
@@ -374,7 +374,6 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
       return;
     }
 
-    if (!mounted) return;
     await participant?.setScreenShareEnabled(true, captureScreenAudio: true);
   }
 

--- a/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/more_option_bottomsheet.dart
@@ -115,7 +115,8 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
                   text:
                       '${(viewModel.room.localParticipant?.isScreenShareEnabled() == true) ? "Stop" : "Start"} Screen Sharing',
                   isVisible: viewModel.meetingDetails.features!
-                      .isScreenSharingAllowed(), onTap: () {
+                      .isScreenSharingAllowed(),
+                  isEnabled: !viewModel.isScreenShareActionInProgress, onTap: () {
                 Navigator.pop(context);
                 if (viewModel.room.localParticipant?.isScreenShareEnabled() ==
                     true) {
@@ -253,6 +254,21 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
   }
 
   void _enableScreenShare(RtcViewmodel viewModel) async {
+    // Guards against overlapping start/stop native calls when the user mashes
+    // the toggle quickly. Stacking up screen-capture start/dispose calls before
+    // the previous one's native teardown (Surface/MediaProjection/codec)
+    // finishes can block the platform thread for several seconds on some
+    // devices and trigger an ANR.
+    if (viewModel.isScreenShareActionInProgress) return;
+    viewModel.isScreenShareActionInProgress = true;
+    try {
+      await _doEnableScreenShare(viewModel);
+    } finally {
+      viewModel.isScreenShareActionInProgress = false;
+    }
+  }
+
+  Future<void> _doEnableScreenShare(RtcViewmodel viewModel) async {
     final participant = viewModel.room.localParticipant;
 
     if (viewModel.isScreenSharePermissionNeeded()) {
@@ -378,6 +394,16 @@ class _MoreOptionState extends State<MoreOptionBottomSheet> {
   }
 
   void _disableScreenShare(RtcViewmodel viewModel) async {
+    if (viewModel.isScreenShareActionInProgress) return;
+    viewModel.isScreenShareActionInProgress = true;
+    try {
+      await _doDisableScreenShare(viewModel);
+    } finally {
+      viewModel.isScreenShareActionInProgress = false;
+    }
+  }
+
+  Future<void> _doDisableScreenShare(RtcViewmodel viewModel) async {
     final participant = viewModel.room.localParticipant;
     await participant?.setScreenShareEnabled(false);
     viewModel

--- a/lib/presentation/dialog/notification_permission_dialog.dart
+++ b/lib/presentation/dialog/notification_permission_dialog.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import '../../resources/colors/color.dart';
+
+void showNotificationPermissionDialog(BuildContext context) {
+  showDialog(
+    context: context,
+    builder: (_) => const NotificationPermissionDialog(),
+  );
+}
+
+class NotificationPermissionDialog extends StatelessWidget {
+  const NotificationPermissionDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 64,
+              height: 64,
+              decoration: BoxDecoration(
+                color: themeColor.withValues(alpha: 0.12),
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(
+                Icons.notifications_active_rounded,
+                color: themeColor,
+                size: 32,
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Keep Your Meeting Alive',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Colors.black87,
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Allow notifications to keep your call running in the background.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Colors.black54,
+                fontSize: 14,
+                height: 1.4,
+              ),
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: themeColor,
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                ),
+                onPressed: () {
+                  openAppSettings();
+                  Navigator.of(context).pop();
+                },
+                child: const Text(
+                  'Open Settings',
+                  style: TextStyle(color: Colors.white),
+                ),
+              ),
+            ),
+            const SizedBox(height: 4),
+            SizedBox(
+              width: double.infinity,
+              child: TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text(
+                  'Maybe Later',
+                  style: TextStyle(color: Colors.black54),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/dialog/notification_permission_dialog.dart
+++ b/lib/presentation/dialog/notification_permission_dialog.dart
@@ -3,15 +3,34 @@ import 'package:permission_handler/permission_handler.dart';
 
 import '../../resources/colors/color.dart';
 
-void showNotificationPermissionDialog(BuildContext context) {
-  showDialog(
+Future<void> showNotificationPermissionDialog(
+  BuildContext context, {
+  String title = 'Keep Your Meeting Alive',
+  String message =
+      'Allow notifications to keep your call running in the background.',
+  String dismissLabel = 'Maybe Later',
+}) {
+  return showDialog(
     context: context,
-    builder: (_) => const NotificationPermissionDialog(),
+    builder: (_) => NotificationPermissionDialog(
+      title: title,
+      message: message,
+      dismissLabel: dismissLabel,
+    ),
   );
 }
 
 class NotificationPermissionDialog extends StatelessWidget {
-  const NotificationPermissionDialog({super.key});
+  final String title;
+  final String message;
+  final String dismissLabel;
+
+  const NotificationPermissionDialog({
+    super.key,
+    required this.title,
+    required this.message,
+    this.dismissLabel = 'Maybe Later',
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -37,20 +56,20 @@ class NotificationPermissionDialog extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 16),
-            const Text(
-              'Keep Your Meeting Alive',
+            Text(
+              title,
               textAlign: TextAlign.center,
-              style: TextStyle(
+              style: const TextStyle(
                 color: Colors.black87,
                 fontSize: 18,
                 fontWeight: FontWeight.bold,
               ),
             ),
             const SizedBox(height: 8),
-            const Text(
-              'Allow notifications to keep your call running in the background.',
+            Text(
+              message,
               textAlign: TextAlign.center,
-              style: TextStyle(
+              style: const TextStyle(
                 color: Colors.black54,
                 fontSize: 14,
                 height: 1.4,
@@ -79,9 +98,9 @@ class NotificationPermissionDialog extends StatelessWidget {
               width: double.infinity,
               child: TextButton(
                 onPressed: () => Navigator.of(context).pop(),
-                child: const Text(
-                  'Maybe Later',
-                  style: TextStyle(color: Colors.black54),
+                child: Text(
+                  dismissLabel,
+                  style: const TextStyle(color: Colors.black54),
                 ),
               ),
             ),

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -499,7 +499,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
       if (localParticipant?.isScreenShareEnabled() == true) {
         if (localParticipant?.identity != track.participant.identity) {
           if (track.participant.isScreenShareEnabled()) {
-            viewModel?.disposeScreenShare();
+            _autoStopLocalScreenShare(viewModel);
           }
         }
       }
@@ -1052,6 +1052,22 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
   void _onE2EEStateEvent(TrackE2EEStateEvent e2eeState) {
     if (kDebugMode) {
       print('e2ee state: $e2eeState');
+    }
+  }
+
+  // Auto-stops the local user's screen share when another participant
+  // (e.g. a web client) starts theirs. Guarded by the same
+  // isScreenShareActionInProgress flag as the manual toggle button so that
+  // a remote participant rapidly starting/stopping their share can't stack
+  // overlapping native teardown calls on top of (or with) a manual toggle —
+  // that race is what triggers ANRs on low-end devices (see 07c022b).
+  void _autoStopLocalScreenShare(RtcViewmodel? viewModel) async {
+    if (viewModel == null || viewModel.isScreenShareActionInProgress) return;
+    viewModel.isScreenShareActionInProgress = true;
+    try {
+      await viewModel.disposeScreenShare();
+    } finally {
+      viewModel.isScreenShareActionInProgress = false;
     }
   }
 

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -9,6 +9,7 @@ import 'package:daakia_vc_flutter_sdk/events/rtc_events.dart';
 import 'package:daakia_vc_flutter_sdk/enum/attendance_role_enum.dart';
 import 'package:daakia_vc_flutter_sdk/model/action_model.dart';
 import 'package:daakia_vc_flutter_sdk/model/meeting_details.dart';
+import 'package:daakia_vc_flutter_sdk/presentation/dialog/notification_permission_dialog.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/widgets/emoji_reaction_widget.dart';
 import 'package:daakia_vc_flutter_sdk/rtc/lobby_request_manager.dart';
 import 'package:daakia_vc_flutter_sdk/rtc/widgets/connectivity_banner.dart';
@@ -204,7 +205,16 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
       };
     }
 
-    handleAndroidNotification(enable: true);
+    unawaited(_setupAndroidMeetingNotification());
+  }
+
+  Future<void> _setupAndroidMeetingNotification() async {
+    await handleAndroidNotification(enable: true);
+    if (!lkPlatformIs(PlatformType.android)) return;
+    final hasPermission = await DaakiaMeetingService.hasNotificationPermission();
+    if (!hasPermission && mounted) {
+      showNotificationPermissionDialog(context);
+    }
   }
 
   bool _isReconnecting = false;

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -335,81 +335,81 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
       onReconnectSuccess();
     })
     ..on<RoomDisconnectedEvent>((event) async {
-      if (event.reason != null) {
-        _isProgrammaticPop = true;
-        DatadogDisconnectLogger.logDisconnectEvent(
-            meetingId: widget.meetingDetails.meetingUid,
-            room: widget.room,
-            reason: event.reason?.name);
-        _livekitProviderKey.currentState?.viewModel.isMeetingEnded = true;
-        clearMemory(_livekitProviderKey.currentState?.viewModel);
-        switch (event.reason) {
-          case DisconnectReason.participantRemoved:
-            {
-              showSnackBar(message: "Host has removed you from the meeting!");
-              Timer(const Duration(seconds: 3), () {
-                if (mounted) {
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    closeMeetingProgrammatically(context);
-                  });
-                }
-              });
-              break;
-            }
-          case DisconnectReason.duplicateIdentity:
-            {
-              showSnackBar(message: "You have joined with another device");
-              Timer(const Duration(seconds: 3), () {
-                if (mounted) {
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    closeMeetingProgrammatically(context);
-                  });
-                }
-              });
-              break;
-            }
-          case DisconnectReason.roomDeleted:
-            {
-              showSnackBar(message: "Meeting ended");
-              Timer(const Duration(seconds: 3), () {
-                if (mounted) {
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    if (!context.mounted) return;
-                    closeMeetingProgrammatically(context);
-                  });
-                }
-              });
-              break;
-            }
-
-          // ✅ New cases with user-friendly messages
-          case null:
-          case DisconnectReason.unknown:
-            _handleGenericDisconnect("Disconnected due to unknown reason.");
+      // Run cleanup and navigation for ALL disconnect reasons, including null.
+      // The outer null-guard that was here made the `case null` in the switch
+      // unreachable — any unexpected disconnect (network drop, server kill
+      // without a reason) would leave the page open and the service running.
+      _isProgrammaticPop = true;
+      DatadogDisconnectLogger.logDisconnectEvent(
+          meetingId: widget.meetingDetails.meetingUid,
+          room: widget.room,
+          reason: event.reason?.name);
+      _livekitProviderKey.currentState?.viewModel.isMeetingEnded = true;
+      clearMemory(_livekitProviderKey.currentState?.viewModel);
+      switch (event.reason) {
+        case DisconnectReason.participantRemoved:
+          {
+            showSnackBar(message: "Host has removed you from the meeting!");
+            Timer(const Duration(seconds: 3), () {
+              if (mounted) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  closeMeetingProgrammatically(context);
+                });
+              }
+            });
             break;
-          case DisconnectReason.clientInitiated:
-            _handleGenericDisconnect("You have left the meeting.");
+          }
+        case DisconnectReason.duplicateIdentity:
+          {
+            showSnackBar(message: "You have joined with another device");
+            Timer(const Duration(seconds: 3), () {
+              if (mounted) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  closeMeetingProgrammatically(context);
+                });
+              }
+            });
             break;
-          case DisconnectReason.serverShutdown:
-            _handleGenericDisconnect("Meeting ended by the server.");
+          }
+        case DisconnectReason.roomDeleted:
+          {
+            showSnackBar(message: "Meeting ended");
+            Timer(const Duration(seconds: 3), () {
+              if (mounted) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (!context.mounted) return;
+                  closeMeetingProgrammatically(context);
+                });
+              }
+            });
             break;
-          case DisconnectReason.stateMismatch:
-            _handleGenericDisconnect("Connection lost due to state mismatch.");
-            break;
-          case DisconnectReason.joinFailure:
-            _handleGenericDisconnect("Failed to join the meeting.");
-            break;
-          case DisconnectReason.disconnected:
-            _handleGenericDisconnect("You have been disconnected.");
-            break;
-          case DisconnectReason.signalingConnectionFailure:
-            _handleGenericDisconnect("Signaling connection failed.");
-            break;
-          case DisconnectReason.reconnectAttemptsExceeded:
-            _handleGenericDisconnect(
-                "Could not reconnect. Please check your internet.");
-            break;
-        }
+          }
+        case null:
+        case DisconnectReason.unknown:
+          _handleGenericDisconnect("Disconnected due to unknown reason.");
+          break;
+        case DisconnectReason.clientInitiated:
+          _handleGenericDisconnect("You have left the meeting.");
+          break;
+        case DisconnectReason.serverShutdown:
+          _handleGenericDisconnect("Meeting ended by the server.");
+          break;
+        case DisconnectReason.stateMismatch:
+          _handleGenericDisconnect("Connection lost due to state mismatch.");
+          break;
+        case DisconnectReason.joinFailure:
+          _handleGenericDisconnect("Failed to join the meeting.");
+          break;
+        case DisconnectReason.disconnected:
+          _handleGenericDisconnect("You have been disconnected.");
+          break;
+        case DisconnectReason.signalingConnectionFailure:
+          _handleGenericDisconnect("Signaling connection failed.");
+          break;
+        case DisconnectReason.reconnectAttemptsExceeded:
+          _handleGenericDisconnect(
+              "Could not reconnect. Please check your internet.");
+          break;
       }
     })
     ..on<ParticipantEvent>((event) {
@@ -1895,7 +1895,9 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
   void clearMemory(RtcViewmodel? viewModel) {
     viewModel?.disposeScreenShare();
     viewModel?.unregisterCaption();
-    handleAndroidNotification(enable: false);
+    // unawaited is intentional — dispose() is synchronous so we can't await here.
+    // DaakiaMeetingService.stop() has its own try-catch and is safe to fire-and-forget.
+    unawaited(handleAndroidNotification(enable: false));
     _disposePip();
     DaakiaPiP.disposePiP();
   }

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -91,6 +91,11 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
 
   Timer? _configRecordingTimer;
 
+  // Coalesces rapid-fire track add/remove events (e.g. both sides repeatedly
+  // toggling screen share) into a single rebuild instead of one per event,
+  // to reduce main-thread churn during toggle storms.
+  Timer? _sortParticipantsDebounceTimer;
+
   late final MeetingManager meetingManager;
 
   @override
@@ -323,6 +328,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     lobbyManager?.dispose();
     widget.room.disconnect();
     handleAndroidNotification(enable: false);
+    _sortParticipantsDebounceTimer?.cancel();
     // always dispose listener
     (() async {
       DaakiaPiP.disposePiP();
@@ -428,7 +434,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
 
       checkRecordingPlayer(widget.room.isRecording);
       // sort participants on many track events as noted in documentation linked above
-      _sortParticipants();
+      _scheduleSortParticipants();
 
       // Debounce `configAutoRecording` to ensure it is called only once within 1 second
       if (_configRecordingTimer?.isActive ?? false) {
@@ -497,7 +503,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
           }
         }
       }
-      _sortParticipants();
+      _scheduleSortParticipants();
     })
     ..on<LocalTrackPublishedEvent>((track){
       var viewModel = _livekitProviderKey.currentState?.viewModel;
@@ -509,7 +515,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
             action: MeetingActions.screenShareStarted,
             timeStamp: DateTime.now().microsecondsSinceEpoch));
       }
-      _sortParticipants();
+      _scheduleSortParticipants();
     })
     ..on<LocalTrackUnpublishedEvent>((track){
       if (track.publication.source == TrackSource.screenShareVideo) {
@@ -517,10 +523,10 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         final localId = widget.room.localParticipant?.identity;
         if (localId != null) viewModel?.resetAnnotationSharer(localId);
       }
-      _sortParticipants();
+      _scheduleSortParticipants();
     })
-    ..on<TrackSubscribedEvent>((_) => _sortParticipants())
-    ..on<TrackUnsubscribedEvent>((_) => _sortParticipants())
+    ..on<TrackSubscribedEvent>((_) => _scheduleSortParticipants())
+    ..on<TrackUnsubscribedEvent>((_) => _scheduleSortParticipants())
     ..on<TrackE2EEStateEvent>(_onE2EEStateEvent)
     ..on<ParticipantNameUpdatedEvent>((event) {
       _sortParticipants();
@@ -1047,6 +1053,14 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
     if (kDebugMode) {
       print('e2ee state: $e2eeState');
     }
+  }
+
+  void _scheduleSortParticipants() {
+    _sortParticipantsDebounceTimer?.cancel();
+    _sortParticipantsDebounceTimer =
+        Timer(const Duration(milliseconds: 200), () {
+      if (mounted) _sortParticipants();
+    });
   }
 
   void _sortParticipants() {

--- a/lib/service/daakia_meeting_service.dart
+++ b/lib/service/daakia_meeting_service.dart
@@ -7,9 +7,8 @@ import 'package:permission_handler/permission_handler.dart';
 class DaakiaMeetingService {
   static const _channel = MethodChannel('io.daakia/meeting_service');
 
-  // Cached params so restartIfActive() can replay the last start() call.
+  // Cached params so restartIfActive() can refresh the notification.
   static String? _title;
-  static String? _text;
   static bool _showMuteButton = false;
   static bool _isMuted = false;
 
@@ -62,7 +61,6 @@ class DaakiaMeetingService {
     if (!Platform.isAndroid && !Platform.isIOS) return;
 
     _title = title;
-    _text = text;
     _isMuted = isMuted;
     _showMuteButton = showMuteButton;
 
@@ -107,14 +105,26 @@ class DaakiaMeetingService {
 
   /// Re-attaches the Android notification after returning from system Settings
   /// (e.g. user just granted POST_NOTIFICATIONS mid-meeting). No-op on iOS.
+  ///
+  /// This is called on every app resume (see RoomPage.didChangeAppLifecycleState),
+  /// which includes the resume that happens right after the screen-capture
+  /// permission dialog closes. It must NOT call start() / startForegroundService()
+  /// here: that re-arms Android's "must call startForeground() within a few
+  /// seconds" watchdog, and racing it against the screen-share flow's own
+  /// startForeground() call (addMediaProjectionType) on a busy main thread can
+  /// throw ForegroundServiceDidNotStartInTimeException (ANR) on slower devices.
+  /// updateMuteState only does a plain startService() + notify() refresh, which
+  /// carries no such timing requirement.
   static Future<void> restartIfActive() async {
     if (!Platform.isAndroid || _title == null) return;
-    await start(
-      title: _title!,
-      text: _text ?? 'Tap to return to the meeting',
-      isMuted: _isMuted,
-      showMuteButton: _showMuteButton,
-    );
+    try {
+      await _channel.invokeMethod('updateMuteState', {
+        'isMuted': _isMuted,
+        'showMuteButton': _showMuteButton,
+      });
+    } catch (e) {
+      debugPrint('DaakiaMeetingService restartIfActive error: $e');
+    }
   }
 
   /// Upgrades the running FGS to include mediaProjection type so that
@@ -148,7 +158,6 @@ class DaakiaMeetingService {
   static Future<void> stop() async {
     if (!Platform.isAndroid && !Platform.isIOS) return;
     _title = null;
-    _text = null;
     _isMuted = false;
     _showMuteButton = false;
     onMuteToggle = null;

--- a/lib/service/daakia_meeting_service.dart
+++ b/lib/service/daakia_meeting_service.dart
@@ -121,12 +121,17 @@ class DaakiaMeetingService {
   /// flutter_webrtc can call getDisplayMedia. Must be called after the user
   /// grants screen capture permission and before setScreenShareEnabled(true).
   /// No-op on iOS and Android < 14 (flutter_background handles it there).
-  static Future<void> startScreenShare() async {
-    if (!Platform.isAndroid) return;
+  /// Returns false if the service is not running (e.g. killed by OS).
+  /// Callers must bail early on false — proceeding to setScreenShareEnabled
+  /// without the FGS mediaProjection type crashes on Android 14+.
+  static Future<bool> startScreenShare() async {
+    if (!Platform.isAndroid) return true;
     try {
       await _channel.invokeMethod('startScreenShareService');
+      return true;
     } catch (e) {
       debugPrint('DaakiaMeetingService startScreenShare error: $e');
+      return false;
     }
   }
 

--- a/lib/service/daakia_meeting_service.dart
+++ b/lib/service/daakia_meeting_service.dart
@@ -103,6 +103,15 @@ class DaakiaMeetingService {
     }
   }
 
+  /// Whether the app currently has permission to show notifications.
+  /// Always true on iOS and on Android versions where POST_NOTIFICATIONS
+  /// isn't a runtime permission (Android < 13). Does not request — callers
+  /// use this after [start] to decide whether to prompt the user themselves.
+  static Future<bool> hasNotificationPermission() async {
+    if (!Platform.isAndroid) return true;
+    return (await Permission.notification.status).isGranted;
+  }
+
   /// Re-attaches the Android notification after returning from system Settings
   /// (e.g. user just granted POST_NOTIFICATIONS mid-meeting). No-op on iOS.
   ///

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -546,6 +546,16 @@ class RtcViewmodel extends ChangeNotifier {
 
   bool isRecordingStartByMe = false;
 
+  bool _isScreenShareActionInProgress = false;
+
+  bool get isScreenShareActionInProgress => _isScreenShareActionInProgress;
+
+  set isScreenShareActionInProgress(bool value) {
+    if (_isScreenShareActionInProgress == value) return;
+    _isScreenShareActionInProgress = value;
+    notifyListeners();
+  }
+
   String? dispatchId;
   bool _stopRecordingRetried = false;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: daakia_vc_flutter_sdk
 description: "A ready-to-use Flutter SDK for seamless audio/video calls, group meetings, and scalable conferencing solutions."
-version: 4.5.0
+version: 4.5.1
 homepage: https://github.com/daakia/daakia_vc_flutter_sdk
 
 environment:


### PR DESCRIPTION
# CHANGELOG

## v4.5.1 – (2026-06)

### 🚀 New Features
- **Notification Permission Dialog (Android)** — Customizable dialog enforcing notification permission before starting screen sharing.

### 🧩 Improvements
- Debounced participant list sorting to reduce main-thread churn.

### 🐞 Bug Fixes
- Fixed concurrent screen-share actions causing ANRs.
- Fixed ANRs during app resume by refactoring `restartIfActive`.
- Fixed cleanup and navigation on all room disconnect events.
- Added missing microphone/camera foreground service types to `DaakiaMeetingService`.
- Fixed screen-share service availability handling on Android 14+.