### PR TITLE
Feat/cryptography logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ migrate_working_dir/
 .pub-cache/
 .pub/
 build/
+test/
 #pubspec.lock
 
 # Android related

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -204,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: datadog_flutter_plugin
-      sha256: cb5c1f8012abc42a5499011cf8a4c6b710c5fb071957f297ad5cc1c1d5a32b35
+      sha256: "927245669bad80bd25a153e562b5b145a396cba0e2cde0fb7dac96c0e3c19607"
       url: "https://pub.dev"
     source: hosted
-    version: "2.16.1"
+    version: "3.3.0"
   dbus:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 4.5.0+6
 
 environment:
-  sdk: ^3.5.3
+  sdk: ^3.8.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -5,21 +5,22 @@ import 'package:daakia_vc_flutter_sdk/model/consent_status_data.dart';
 import 'package:daakia_vc_flutter_sdk/model/egress_data.dart';
 import 'package:daakia_vc_flutter_sdk/model/feature_data.dart';
 import 'package:daakia_vc_flutter_sdk/model/licence_verify_model.dart';
+import 'package:daakia_vc_flutter_sdk/model/observability_payload_model.dart';
 import 'package:daakia_vc_flutter_sdk/model/participant_attendance_data.dart';
+import 'package:daakia_vc_flutter_sdk/model/participant_drawer_consent_model.dart';
 import 'package:daakia_vc_flutter_sdk/model/screen_share_consent_model.dart';
 import 'package:daakia_vc_flutter_sdk/model/session_details_data.dart';
 import 'package:daakia_vc_flutter_sdk/model/translation_data.dart';
 import 'package:daakia_vc_flutter_sdk/model/webinar_permission_model.dart';
-import 'package:daakia_vc_flutter_sdk/model/participant_drawer_consent_model.dart';
 import 'package:daakia_vc_flutter_sdk/model/workshop_permission_model.dart';
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 
 import '../model/agent_dispatch_data.dart';
-import '../model/host_controls_data.dart';
 import '../model/base_list_response.dart';
 import '../model/base_response.dart';
 import '../model/event_password_protected_data.dart';
+import '../model/host_controls_data.dart';
 import '../model/host_token_model.dart';
 import '../model/meeting_details_model.dart';
 import '../model/recording_dispatch_data.dart';
@@ -78,7 +79,17 @@ abstract class RestClient {
 
   @GET("saas/sdk/meeting/basic/detail")
   Future<BaseResponse<MeetingDetailsModel>> getMeetingDetails(
-      @Query("meeting_uid") String meetingUid, @Header("secret") String secret);
+    @Query("meeting_uid") String meetingUid,
+    @Header("secret") String secret,
+  );
+
+  //-------------------[OBSERVABILITY]-------------------
+
+  @POST("saas/sdk/observability/credentials")
+  Future<BaseResponse<ObservabilityPayloadModel>> getObservabilityCredentials(
+    @Header("secret") String secret,
+    @Body() Map<String, dynamic> body,
+  );
 
   //-------------------[RTC]-------------------
 

--- a/lib/api/api_client.g.dart
+++ b/lib/api/api_client.g.dart
@@ -1711,6 +1711,42 @@ class _RestClient implements RestClient {
     return _value;
   }
 
+  @override
+  Future<BaseResponse<ObservabilityPayloadModel>> getObservabilityCredentials(
+    String secret,
+    Map<String, dynamic> body,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'secret': secret};
+    _headers.removeWhere((k, v) => v == null);
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
+    final _options = _setStreamType<BaseResponse<ObservabilityPayloadModel>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            'saas/sdk/observability/credentials',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseResponse<ObservabilityPayloadModel> _value;
+    try {
+      _value = BaseResponse<ObservabilityPayloadModel>.fromJson(
+        _result.data!,
+        (json) =>
+            ObservabilityPayloadModel.fromJson(json as Map<String, dynamic>),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/daakia_vc_flutter_sdk.dart
+++ b/lib/daakia_vc_flutter_sdk.dart
@@ -10,55 +10,68 @@ import 'model/daakia_meeting_configuration.dart';
 import 'model/meeting_details_model.dart';
 import 'utils/constants.dart';
 
-/// Optional SDK-level configuration. Call [DaakiaSdk.initialize] once in your
-/// app's startup (e.g. before [runApp]) to override default URLs.
+/// SDK-level configuration. Call [DaakiaSdk.initialize] once in your app's
+/// startup (e.g. in [main] before [runApp]).
 ///
+/// **New flow — recommended:**
 /// ```dart
 /// DaakiaSdk.initialize(
-///   baseUrl: '<BASE_URL>',
-///   whiteboardDomain: '<WHITEBOARD_URL>',
+///   secret: '<YOUR_SECRET_KEY>',
+///   baseUrl: '<BASE_URL>',         // optional, defaults to production
+///   whiteboardDomain: '<WB_URL>',  // optional
 /// );
 /// ```
 ///
-/// Omitting a parameter keeps the production default.
+/// Once the secret is set here, omit [secretKey] from [DaakiaVideoConferenceWidget].
+/// Omitting any parameter keeps the current default.
 class DaakiaSdk {
   DaakiaSdk._();
 
+  static String? _secret;
+
   static void initialize({
+    String? secret,
     String? baseUrl,
     String? whiteboardDomain,
   }) {
-    if (baseUrl != null) {
-      Constant.baseUrl = baseUrl;
-    }
-    if (whiteboardDomain != null) {
-      Constant.whiteboardDomain = whiteboardDomain;
-    }
+    if (secret != null) _secret = secret;
+    if (baseUrl != null) Constant.baseUrl = baseUrl;
+    if (whiteboardDomain != null) Constant.whiteboardDomain = whiteboardDomain;
   }
 }
 
 class DaakiaVideoConferenceWidget extends StatefulWidget {
   /// Creates a new instance of the [DaakiaVideoConferenceWidget].
   ///
-  /// [secretKey] is the license key required for authenticating the meeting session.
-  /// [meetingId] is the unique identifier for the meeting.
-  /// [isHost] determines if the current participant is the meeting host.
-  /// [configuration] provides optional advanced customizations.
-  const DaakiaVideoConferenceWidget(
-      {required this.meetingId,
-      required this.secretKey,
-      this.isHost = false,
-      this.configuration,
-      super.key});
+  /// **Recommended:** Set the secret key once at app startup via
+  /// [DaakiaSdk.initialize] and omit [secretKey] here:
+  /// ```dart
+  /// // main.dart
+  /// DaakiaSdk.initialize(secret: '<YOUR_SECRET_KEY>');
+  ///
+  /// // meeting screen
+  /// DaakiaVideoConferenceWidget(meetingId: id, isHost: true)
+  /// ```
+  ///
+  /// Passing [secretKey] directly still works but is deprecated — move it to
+  /// [DaakiaSdk.initialize] to avoid repeating it on every widget instantiation.
+  const DaakiaVideoConferenceWidget({
+    required this.meetingId,
+    this.secretKey,
+    this.isHost = false,
+    this.configuration,
+    super.key,
+  });
 
   /// Unique identifier for the meeting session.
   final String meetingId;
 
   /// License key used to verify and authorize access to the meeting.
   ///
-  /// This key is validated before allowing the user to join the session.
-  /// Make sure the provided key is valid for the associated [meetingId].
-  final String secretKey;
+  /// Deprecated: pass the secret key via [DaakiaSdk.initialize] at app startup
+  /// and remove this parameter from the widget. It will be removed in a future
+  /// major version.
+  final String? secretKey;
 
   /// Determines whether the user is a host.
   ///
@@ -82,23 +95,40 @@ class _DaakiaVideoConferenceState extends State<DaakiaVideoConferenceWidget> {
   var _verified = false;
   var _licenseMessage = "";
   MeetingDetailsModel? meetingDetails;
+  late final String? _secret;
 
   @override
   void initState() {
-    _verifyLicense();
     super.initState();
+    _secret = widget.secretKey ?? DaakiaSdk._secret;
+    if (widget.secretKey != null) {
+      debugPrint(
+        '[DaakiaSDK] secretKey passed directly to DaakiaVideoConferenceWidget is deprecated. '
+        'Move it to DaakiaSdk.initialize(secret: yourKey) in main() and remove it from the widget.',
+      );
+    }
+    _verifyLicense();
   }
 
   void _verifyLicense() {
+    if (_secret == null || _secret.isEmpty) {
+      setState(() {
+        _isLoading = false;
+        _licenseMessage =
+            'DaakiaSdk secret key is not configured. '
+            'Call DaakiaSdk.initialize(secret: \'<your_key>\') in main() '
+            'before launching DaakiaVideoConferenceWidget.';
+      });
+      return;
+    }
     setState(() {
       _isLoading = true;
     });
-    Map<String, dynamic> body = {
-      "secret_key": widget.secretKey,
-      "meeting_uid": widget.meetingId
-    };
     networkRequestHandler(
-        apiCall: () => apiClient.licenceVerify(body),
+        apiCall: () => apiClient.licenceVerify({
+              "secret_key": _secret,
+              "meeting_uid": widget.meetingId,
+            }),
         onSuccess: (data) {
           _verified = data?.userVerified ?? false;
           if (_verified) {
@@ -123,7 +153,7 @@ class _DaakiaVideoConferenceState extends State<DaakiaVideoConferenceWidget> {
   void _getMeetingDetails() {
     networkRequestHandler(
       apiCall: () =>
-          apiClient.getMeetingDetails(widget.meetingId, widget.secretKey),
+          apiClient.getMeetingDetails(widget.meetingId, _secret!),
       onSuccess: (response) {
         meetingDetails = response;
         setState(() {
@@ -148,7 +178,7 @@ class _DaakiaVideoConferenceState extends State<DaakiaVideoConferenceWidget> {
     } else if (_verified) {
       screen = PreJoinScreen(
         meetingId: widget.meetingId,
-        secretKey: widget.secretKey,
+        secretKey: _secret!,
         isHost: widget.isHost,
         basicMeetingDetails: meetingDetails,
         configuration: widget.configuration,

--- a/lib/daakia_vc_flutter_sdk.dart
+++ b/lib/daakia_vc_flutter_sdk.dart
@@ -1,14 +1,22 @@
 library daakia_vc_flutter_sdk;
 
+import 'dart:convert';
+
 import 'package:daakia_vc_flutter_sdk/api/injection.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/screens/license_expired.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/screens/loading_screen.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/screens/prejoin_screen.dart';
 import 'package:flutter/widgets.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 import 'model/daakia_meeting_configuration.dart';
 import 'model/meeting_details_model.dart';
+import 'model/observability_config.dart';
+import 'model/observability_payload_model.dart';
+import 'service/daakia_vc_datadog_service.dart';
+import 'service/daakia_vc_sentry_service.dart';
 import 'utils/constants.dart';
+import 'utils/sdk_crypto.dart';
 
 /// SDK-level configuration. Call [DaakiaSdk.initialize] once in your app's
 /// startup (e.g. in [main] before [runApp]).
@@ -133,6 +141,7 @@ class _DaakiaVideoConferenceState extends State<DaakiaVideoConferenceWidget> {
           _verified = data?.userVerified ?? false;
           if (_verified) {
             _getMeetingDetails();
+            _initObservability();
             return;
           } else {
             _licenseMessage = "License key not verified!";
@@ -148,6 +157,43 @@ class _DaakiaVideoConferenceState extends State<DaakiaVideoConferenceWidget> {
             _licenseMessage = message;
           });
         });
+  }
+
+  Future<void> _initObservability() async {
+    if (DaakiaVcDatadogService.isInitialized && DaakiaVcSentryService.isInitialized) return;
+    try {
+      PackageInfo? pkgInfo;
+      try { pkgInfo = await PackageInfo.fromPlatform(); } catch (_) {}
+
+      final body = <String, dynamic>{
+        'sdk_name': Constant.sdkName,
+        'sdk_version': Constant.sdkVersion,
+        if (pkgInfo != null) ...{
+          'app_name': pkgInfo.appName,
+          'app_version': pkgInfo.version,
+          'app_identifier': pkgInfo.packageName,
+        },
+      };
+
+      await networkRequestHandler<ObservabilityPayloadModel>(
+        apiCall: () => apiClient.getObservabilityCredentials(_secret!, body),
+        onSuccess: (data) async {
+          final payload = data?.payload;
+          if (payload == null) return;
+          final json = SdkCrypto.decryptPayload(payload, _secret!);
+          if (json == null) return;
+          final config = ObservabilityConfigModel.fromJson(
+            jsonDecode(json) as Map<String, dynamic>,
+          );
+          if (config.datadog != null) {
+            await DaakiaVcDatadogService.initializeFromConfig(config.datadog!);
+          }
+          if (config.sentry != null) {
+            await DaakiaVcSentryService.initializeFromConfig(config.sentry!);
+          }
+        },
+      );
+    } catch (_) {}
   }
 
   void _getMeetingDetails() {

--- a/lib/model/observability_config.dart
+++ b/lib/model/observability_config.dart
@@ -1,17 +1,23 @@
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import '../utils/constants.dart';
 
 class DatadogObsConfig {
   final String clientToken;
   final String applicationId;
   final String env;
   final DatadogSite site;
+  final String serviceName;
+  final String version;
 
-  const DatadogObsConfig({
+  DatadogObsConfig({
     required this.clientToken,
     required this.applicationId,
     required this.env,
     this.site = DatadogSite.us3,
-  });
+    String? serviceName,
+    String? version,
+  })  : serviceName = serviceName ?? 'vc-${Constant.platform}-log',
+        version = version ?? Constant.sdkVersion;
 
   factory DatadogObsConfig.fromJson(Map<String, dynamic> json) {
     return DatadogObsConfig(

--- a/lib/model/observability_config.dart
+++ b/lib/model/observability_config.dart
@@ -2,24 +2,61 @@ import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 
 class DatadogObsConfig {
   final String clientToken;
-  final String env;
-  final String serviceName;
   final String applicationId;
-  final String? version;
+  final String env;
   final DatadogSite site;
 
   const DatadogObsConfig({
     required this.clientToken,
-    required this.env,
-    required this.serviceName,
     required this.applicationId,
-    this.version,
+    required this.env,
     this.site = DatadogSite.us3,
   });
+
+  factory DatadogObsConfig.fromJson(Map<String, dynamic> json) {
+    return DatadogObsConfig(
+      clientToken: json['client_token'] as String,
+      applicationId: json['application_id'] as String,
+      env: json['env'] as String,
+      site: _parseSite(json['site'] as String? ?? 'us3'),
+    );
+  }
+
+  static DatadogSite _parseSite(String site) {
+    switch (site) {
+      case 'us1': return DatadogSite.us1;
+      case 'us3': return DatadogSite.us3;
+      case 'us5': return DatadogSite.us5;
+      case 'eu1': return DatadogSite.eu1;
+      case 'ap1': return DatadogSite.ap1;
+      default:    return DatadogSite.us3;
+    }
+  }
 }
 
 class SentryObsConfig {
   final String dsn;
 
   const SentryObsConfig({required this.dsn});
+
+  factory SentryObsConfig.fromJson(Map<String, dynamic> json) =>
+      SentryObsConfig(dsn: json['dsn'] as String);
+}
+
+class ObservabilityConfigModel {
+  final DatadogObsConfig? datadog;
+  final SentryObsConfig? sentry;
+
+  const ObservabilityConfigModel({this.datadog, this.sentry});
+
+  factory ObservabilityConfigModel.fromJson(Map<String, dynamic> json) {
+    return ObservabilityConfigModel(
+      datadog: json['datadog'] != null
+          ? DatadogObsConfig.fromJson(json['datadog'] as Map<String, dynamic>)
+          : null,
+      sentry: json['sentry'] != null
+          ? SentryObsConfig.fromJson(json['sentry'] as Map<String, dynamic>)
+          : null,
+    );
+  }
 }

--- a/lib/model/observability_payload_model.dart
+++ b/lib/model/observability_payload_model.dart
@@ -1,0 +1,10 @@
+class ObservabilityPayloadModel {
+  final String? payload;
+
+  ObservabilityPayloadModel({this.payload});
+
+  ObservabilityPayloadModel.fromJson(Map<String, dynamic> json)
+      : payload = json['payload'] as String?;
+
+  Map<String, dynamic> toJson() => {'payload': payload};
+}

--- a/lib/service/daakia_vc_datadog_service.dart
+++ b/lib/service/daakia_vc_datadog_service.dart
@@ -1,6 +1,5 @@
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import '../model/observability_config.dart';
-import '../utils/constants.dart';
 
 class DaakiaVcDatadogService {
   static DatadogLogger? _logger;
@@ -44,8 +43,8 @@ class DaakiaVcDatadogService {
       clientToken: config.clientToken,
       applicationId: config.applicationId,
       env: config.env,
-      serviceName: 'vc-${Constant.platform}-log',
-      version: null,
+      serviceName: config.serviceName,
+      version: config.version,
       site: config.site,
     );
   }

--- a/lib/service/daakia_vc_datadog_service.dart
+++ b/lib/service/daakia_vc_datadog_service.dart
@@ -3,6 +3,8 @@ import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 class DaakiaVcDatadogService {
   static DatadogLogger? _logger;
 
+  static bool get isInitialized => _logger != null;
+
   static Future<void> initialize({
     required String clientToken,
     required String env,
@@ -12,6 +14,7 @@ class DaakiaVcDatadogService {
     DatadogSite site = DatadogSite.us3,
     bool enableCrashReporting = true,
   }) async {
+    if (_logger != null) return;
     final configuration = DatadogConfiguration(
       clientToken: clientToken,
       env: env,

--- a/lib/service/daakia_vc_datadog_service.dart
+++ b/lib/service/daakia_vc_datadog_service.dart
@@ -1,4 +1,6 @@
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import '../model/observability_config.dart';
+import '../utils/constants.dart';
 
 class DaakiaVcDatadogService {
   static DatadogLogger? _logger;
@@ -34,6 +36,17 @@ class DaakiaVcDatadogService {
 
     _logger = DatadogSdk.instance.logs?.createLogger(
       DatadogLoggerConfiguration(remoteLogThreshold: LogLevel.info),
+    );
+  }
+
+  static Future<void> initializeFromConfig(DatadogObsConfig config) async {
+    await initialize(
+      clientToken: config.clientToken,
+      applicationId: config.applicationId,
+      env: config.env,
+      serviceName: 'vc-${Constant.platform}-log',
+      version: null,
+      site: config.site,
     );
   }
 

--- a/lib/service/daakia_vc_sentry_service.dart
+++ b/lib/service/daakia_vc_sentry_service.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+import '../model/observability_config.dart';
 import '../utils/constants.dart';
 
 /// Internal Sentry service for SDK-level error and event tracking.
@@ -21,6 +22,10 @@ class DaakiaVcSentryService {
   static String? _osVersion;
 
   static bool get isInitialized => _client != null;
+
+  static Future<void> initializeFromConfig(SentryObsConfig config) async {
+    await initialize(dsn: config.dsn);
+  }
 
   static Future<void> initialize({required String dsn}) async {
     if (_client != null) return;
@@ -42,7 +47,7 @@ class DaakiaVcSentryService {
       }
 
       _options = SentryOptions(dsn: dsn)
-        ..release = 'daakia_vc_flutter_sdk@${Constant.sdkVersion}'
+        ..release = '${Constant.sdkName}@${Constant.sdkVersion}'
         ..tracesSampleRate = 1.0;
       _client = SentryClient(_options!);
       _hookFlutterErrorHandlers();

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -43,7 +43,7 @@ class Constant {
     if (Platform.isAndroid) {
       return "android";
     } else if (Platform.isIOS) {
-      return "iOS";
+      return "ios";
     } else {
       return "unknown";
     }

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 class Constant {
   static const String sdkVersion = '4.5.1';
+  static const String sdkName = 'daakia_vc_flutter_sdk';
 
   static final String platform = getPlatform();
 

--- a/lib/utils/sdk_crypto.dart
+++ b/lib/utils/sdk_crypto.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:pointycastle/export.dart';
+
+class SdkCrypto {
+  static const _s0 = [0x29, 0xa1, 0xfd, 0x70, 0xb7, 0x1b, 0x97, 0x5b];
+  static const _s1 = [0xbf, 0xff, 0xe6, 0xca, 0xe9, 0x80, 0x73, 0xfb];
+  static const _s2 = [0x9d, 0x6f, 0x48, 0x47, 0x28, 0x1b, 0x62, 0x5b];
+  static const _s3 = [0x0b, 0xe6, 0x34, 0xc2, 0x31, 0x78, 0x2c, 0x4c];
+
+  static const _x0 = 0x6E;
+  static const _x1 = 0xB3;
+  static const _x2 = 0x2A;
+  static const _x3 = 0xF7;
+
+  static const String _hkdfInfo = 'daakia_obs_v1';
+
+  /// Decrypts a base64-encoded AES-256-GCM payload from the observability endpoint.
+  /// Blob layout: [12 bytes IV] + [N bytes ciphertext] + [16 bytes GCM tag]
+  /// Returns decrypted JSON string, or null on any failure.
+  static String? decryptPayload(String base64Payload, String licenseKey) {
+    try {
+      final blob = base64Decode(base64Payload);
+      if (blob.length < 28) return null;
+
+      final iv         = Uint8List.fromList(blob.sublist(0, 12));
+      final ciphertext = blob.sublist(12, blob.length - 16);
+      final tag        = blob.sublist(blob.length - 16);
+
+      final key = _deriveKey(licenseKey);
+
+      final ctWithTag = Uint8List(ciphertext.length + tag.length)
+        ..setRange(0, ciphertext.length, ciphertext)
+        ..setRange(ciphertext.length, ciphertext.length + tag.length, tag);
+
+      final params = AEADParameters(
+        KeyParameter(key),
+        128,
+        iv,
+        Uint8List(0),
+      );
+
+      final gcm = GCMBlockCipher(AESEngine())..init(false, params);
+
+      final output = Uint8List(ciphertext.length);
+      var offset = 0;
+      offset += gcm.processBytes(ctWithTag, 0, ctWithTag.length, output, offset);
+      gcm.doFinal(output, offset);
+
+      return utf8.decode(output);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static Uint8List _deriveKey(String licenseKey) {
+    final ikm  = Uint8List.fromList(utf8.encode(licenseKey));
+    final salt = _assembleSalt();
+    final info = Uint8List.fromList(ascii.encode(_hkdfInfo));
+
+    final hkdf = HKDFKeyDerivator(SHA256Digest());
+    hkdf.init(HkdfParameters(ikm, 32, salt, info));
+
+    final key = Uint8List(32);
+    hkdf.deriveKey(null, 0, key, 0);
+    return key;
+  }
+
+  static Uint8List _assembleSalt() {
+    return Uint8List.fromList([
+      ..._s0.map((b) => b ^ _x0),
+      ..._s1.map((b) => b ^ _x1),
+      ..._s2.map((b) => b ^ _x2),
+      ..._s3.map((b) => b ^ _x3),
+    ]);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1033,7 +1033,7 @@ packages:
     source: hosted
     version: "2.1.8"
   pointycastle:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pointycastle
       sha256: "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -285,10 +285,10 @@ packages:
     dependency: "direct main"
     description:
       name: datadog_flutter_plugin
-      sha256: cb5c1f8012abc42a5499011cf8a4c6b710c5fb071957f297ad5cc1c1d5a32b35
+      sha256: "927245669bad80bd25a153e562b5b145a396cba0e2cde0fb7dac96c0e3c19607"
       url: "https://pub.dev"
     source: hosted
-    version: "2.16.1"
+    version: "3.3.0"
   dbus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   datadog_flutter_plugin: ^2.16.1
   connectivity_plus: ^7.0.0
   device_info_plus: ^12.2.0
+  pointycastle: ^4.0.0
 
 dev_dependencies:
   sentry_dart_plugin: ^3.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   webview_flutter_android: ^4.10.1
   webview_flutter_wkwebview: ^3.23.0
   audioplayers: ^6.5.1
-  datadog_flutter_plugin: ^2.16.1
+  datadog_flutter_plugin: ^3.3.0
   connectivity_plus: ^7.0.0
   device_info_plus: ^12.2.0
   pointycastle: ^4.0.0

--- a/test/daakia_vc_flutter_sdk_test.dart
+++ b/test/daakia_vc_flutter_sdk_test.dart
@@ -1,8 +1,0 @@
-void main() {
-  // test('adds one to input values', () {
-  //   final calculator = Calculator();
-  //   expect(calculator.addOne(2), 3);
-  //   expect(calculator.addOne(-7), -6);
-  //   expect(calculator.addOne(0), 1);
-  // });
-}


### PR DESCRIPTION
## Summary

This PR introduces secure observability initialization for the SDK, including encrypted credential handling, runtime configuration of Datadog and Sentry, and global secret key support.

## Changes

- Added `pointycastle` as a direct dependency.
- Introduced `SdkCrypto` for AES-256-GCM payload decryption with HKDF-SHA256 key derivation.
- Added observability credentials API support through `getObservabilityCredentials`.
- Added `ObservabilityPayloadModel` for observability configuration payload handling.
- Implemented secure retrieval and decryption of observability credentials during SDK initialization.
- Added global secret key support in `DaakiaSdk.initialize()` and deprecated widget-level secret configuration.
- Added validation to ensure a secret key is available before license verification.
- Introduced unified observability initialization for Datadog and Sentry after successful SDK verification.
- Added `DatadogObsConfig` and `SentryObsConfig` based initialization flows.
- Added initialization guards to prevent redundant Datadog service setup.
- Added `sdkName` constant and standardized release/service naming conventions.
- Enhanced Datadog configuration with customizable service name and version support.
- Normalized iOS platform identifiers to lowercase for consistent platform handling.
- Added collection of host application metadata (app name, package name, version) during observability initialization.
- Updated Datadog dependency to `3.3.0` and aligned Dart SDK requirements.
- Updated `.gitignore` to exclude local test artifacts.