### PR TITLE
Doc/use-call-terminology

### DIFF
--- a/doc/DaakiaMeetingConfiguration.md
+++ b/doc/DaakiaMeetingConfiguration.md
@@ -14,6 +14,7 @@ It includes optional metadata, participant name behavior, pre-join flow behavior
 - [Skip Pre-Join Page](#skip-pre-join-page)
 - [Default Mic and Camera State](#default-mic-and-camera-state)
 - [Save Attachments to Downloads](#save-attachments-to-downloads)
+- [Session Terminology](#session-terminology)
 - [Examples](#examples)
 - [Best Practices](#best-practices)
 
@@ -245,6 +246,30 @@ DaakiaMeetingConfiguration(
 ```
 
 ---
+## Session Terminology
+
+The `useCallTerminology` flag controls the labels shown in the end-session bottom sheet.
+
+> **Default:** `false` — the bottom sheet uses "Meeting" terminology ("End Meeting" / "Leave Meeting").
+
+### Behavior
+
+| Value | End button label | Leave button label |
+|-------|------------------|--------------------|
+| `false` (default) | End Meeting | Leave Meeting |
+| `true` | End Call | Leave Call |
+
+Use `true` for 1:1 or call-style experiences where "meeting" language feels out of place.
+
+### Example
+
+```dart
+DaakiaMeetingConfiguration(
+  useCallTerminology: true,
+);
+```
+
+---
 ## Examples
 
 ### Example 1: Basic Metadata
@@ -297,3 +322,4 @@ DaakiaMeetingConfiguration(
 - **Future-Proofing:** Since this is a BETA feature, keep your implementation flexible to accommodate future updates or new fields.
 - **Permission Flow:** If you use `skipPreJoinPage` and expect mic/camera to start enabled, request camera/microphone permission in your app before opening the SDK. Otherwise the SDK joins with those devices disabled.
 - **Save Attachments:** `saveAttachmentToDownloads` is opt-in and off by default. Enable it only when you want received files to persist after the meeting. On iOS, pair it with `UIFileSharingEnabled` in `Info.plist` so users can find their files in the Files app.
+- **Session Terminology:** Use `useCallTerminology: true` only for call-style experiences (e.g., 1:1 video calls). Keep the default for group meetings where "meeting" language is appropriate.

--- a/lib/model/daakia_meeting_configuration.dart
+++ b/lib/model/daakia_meeting_configuration.dart
@@ -83,6 +83,13 @@ class DaakiaMeetingConfiguration {
   /// Defaults to `false` when not provided.
   final bool? saveAttachmentToDownloads;
 
+  /// When true, the end-session bottom sheet labels use "Call" terminology
+  /// ("End Call" / "Leave Call") instead of the default "Meeting" terminology
+  /// ("End Meeting" / "Leave Meeting").
+  ///
+  /// Defaults to `false` when not provided.
+  final bool? useCallTerminology;
+
   const DaakiaMeetingConfiguration({
     this.metadata,
     this.participantNameConfig,
@@ -91,5 +98,6 @@ class DaakiaMeetingConfiguration {
     this.enableCameraByDefault,
     this.vcConfig,
     this.saveAttachmentToDownloads,
+    this.useCallTerminology,
   });
 }

--- a/lib/presentation/bottom_sheets/end_meeting_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/end_meeting_bottomsheet.dart
@@ -5,9 +5,10 @@ import '../../resources/colors/color.dart';
 class EndMeetingBottomSheet extends StatefulWidget {
   final VoidCallback onEndCall;
   final VoidCallback onLeaveCall;
+  final bool useCallTerminology;
 
   const EndMeetingBottomSheet(
-      {required this.onEndCall, required this.onLeaveCall, super.key});
+      {required this.onEndCall, required this.onLeaveCall, this.useCallTerminology = false, super.key});
 
   @override
   State<EndMeetingBottomSheet> createState() => _EndMeetingBottomSheetState();
@@ -40,9 +41,9 @@ class _EndMeetingBottomSheetState extends State<EndMeetingBottomSheet> {
                   borderRadius: BorderRadius.circular(16.0), // Rounded corners
                 ),
               ),
-              child: const Text(
-                "End Call",
-                style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+              child: Text(
+                widget.useCallTerminology ? "End Call" : "End Meeting",
+                style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
               ),
             ),
           ),
@@ -59,9 +60,9 @@ class _EndMeetingBottomSheetState extends State<EndMeetingBottomSheet> {
                   borderRadius: BorderRadius.circular(16.0), // Rounded corners
                 ),
               ),
-              child: const Text(
-                "Leave Call",
-                style: TextStyle(color: Colors.black, fontWeight: FontWeight.bold),
+              child: Text(
+                widget.useCallTerminology ? "Leave Call" : "Leave Meeting",
+                style: const TextStyle(color: Colors.black, fontWeight: FontWeight.bold),
               ),
             ),
           ),

--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -775,7 +775,7 @@ class _PreJoinState extends State<PreJoinScreen> {
         final navigator = Navigator.of(this.context);
         await navigator.push<void>(
           MaterialPageRoute(
-              builder: (_) => RoomPage(room, listener, meetingDetails, fastConnection: true, saveAttachmentToDownloads: widget.configuration?.saveAttachmentToDownloads == true)),
+              builder: (_) => RoomPage(room, listener, meetingDetails, fastConnection: true, sdkConfiguration: widget.configuration)),
         );
         if (mounted && navigator.canPop()) {
           navigator.pop();

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -874,7 +874,10 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         break;
 
       case MeetingActions.requestPublicChat:
-        viewModel?.sendPublicChatHistory(remoteData.userIdentity);
+        final requesterIdentity = (remoteData.userIdentity?.isNotEmpty == true)
+            ? remoteData.userIdentity
+            : remoteData.identity?.identity;
+        viewModel?.sendPublicChatHistory(requesterIdentity);
         break;
 
       case MeetingActions.responsePublicChat:

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -8,6 +8,7 @@ import 'package:daakia_vc_flutter_sdk/events/meeting_end_events.dart';
 import 'package:daakia_vc_flutter_sdk/events/rtc_events.dart';
 import 'package:daakia_vc_flutter_sdk/enum/attendance_role_enum.dart';
 import 'package:daakia_vc_flutter_sdk/model/action_model.dart';
+import 'package:daakia_vc_flutter_sdk/model/daakia_meeting_configuration.dart';
 import 'package:daakia_vc_flutter_sdk/model/meeting_details.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/dialog/notification_permission_dialog.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/widgets/emoji_reaction_widget.dart';
@@ -58,14 +59,14 @@ class RoomPage extends StatefulWidget {
   final EventsListener<RoomEvent> listener;
   final MeetingDetails meetingDetails;
   final bool fastConnection;
-  final bool saveAttachmentToDownloads;
+  final DaakiaMeetingConfiguration? sdkConfiguration;
 
   const RoomPage(
     this.room,
     this.listener,
     this.meetingDetails, {
     this.fastConnection = false,
-    this.saveAttachmentToDownloads = false,
+    this.sdkConfiguration,
     super.key,
   });
 
@@ -1267,7 +1268,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         key: _livekitProviderKey,
         room: widget.room,
         meetingDetails: widget.meetingDetails,
-        saveAttachmentToDownloads: widget.saveAttachmentToDownloads,
+        sdkConfiguration: widget.sdkConfiguration,
         child: MaterialApp(
           navigatorKey: _innerNavigatorKey,
           debugShowCheckedModeBanner: false,

--- a/lib/rtc/widgets/rtc_controls.dart
+++ b/lib/rtc/widgets/rtc_controls.dart
@@ -464,6 +464,7 @@ class _RtcControlState extends State<RtcControls> with WidgetsBindingObserver {
       ),
       builder: (context) {
         return EndMeetingBottomSheet(
+          useCallTerminology: viewModel.useCallTerminology,
           onEndCall: () {
             Navigator.pop(context);
             viewModel.endMeetingForAll();

--- a/lib/viewmodel/rtc_provider.dart
+++ b/lib/viewmodel/rtc_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../model/daakia_meeting_configuration.dart';
 import '../model/meeting_details.dart';
 import 'rtc_viewmodel.dart';
 import 'package:livekit_client/livekit_client.dart';
@@ -8,13 +9,13 @@ class RtcProvider extends StatefulWidget {
   final Room room;
   final MeetingDetails meetingDetails;
   final Widget child;
-  final bool saveAttachmentToDownloads;
+  final DaakiaMeetingConfiguration? sdkConfiguration;
 
   const RtcProvider({
     required this.room,
     required this.meetingDetails,
     required this.child,
-    this.saveAttachmentToDownloads = false,
+    this.sdkConfiguration,
     super.key,
   });
 
@@ -28,7 +29,7 @@ class RtcProviderState extends State<RtcProvider> {
   @override
   void initState() {
     super.initState();
-    viewModel = RtcViewmodel(widget.room, widget.meetingDetails, saveAttachmentToDownloads: widget.saveAttachmentToDownloads);
+    viewModel = RtcViewmodel(widget.room, widget.meetingDetails, sdkConfiguration: widget.sdkConfiguration);
   }
 
   @override

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:collection/collection.dart';
+import 'package:daakia_vc_flutter_sdk/model/daakia_meeting_configuration.dart';
 import 'package:daakia_vc_flutter_sdk/api/injection.dart';
 import 'package:daakia_vc_flutter_sdk/events/rtc_events.dart';
 import 'package:daakia_vc_flutter_sdk/model/consent_participant.dart';
@@ -126,9 +127,12 @@ class RtcViewmodel extends ChangeNotifier {
     notifyListeners();
   }
 
-  final bool saveAttachmentToDownloads;
+  final DaakiaMeetingConfiguration? sdkConfiguration;
 
-  RtcViewmodel(this.room, this.meetingDetails, {this.saveAttachmentToDownloads = false});
+  bool get saveAttachmentToDownloads => sdkConfiguration?.saveAttachmentToDownloads == true;
+  bool get useCallTerminology => sdkConfiguration?.useCallTerminology == true;
+
+  RtcViewmodel(this.room, this.meetingDetails, {this.sdkConfiguration});
 
   List<RemoteActivityData> getMessageList() {
     return _messageList;

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2989,7 +2989,7 @@ class RtcViewmodel extends ChangeNotifier {
   }
 
   void sendPublicChatHistory(String? identity) {
-    if (identity == null) return;
+    if (identity == null || identity.isEmpty) return;
     final payload = ChatMessageMapper.toApiList(getMessageList());
     sendPrivateAction(
       ActionModel(action: MeetingActions.responsePublicChat, messages: payload, userIdentity: room.localParticipant?.identity),


### PR DESCRIPTION
## Summary

This PR enhances meeting configuration handling by introducing configuration-driven session terminology and centralizing SDK settings across the RTC flow.

## Changes

- Replaced the standalone `saveAttachmentToDownloads` flag with `DaakiaMeetingConfiguration` throughout `RoomPage`, `RtcProvider`, and `RtcViewmodel`.
- Added `useCallTerminology` to `DaakiaMeetingConfiguration` to support call-oriented UI wording.
- Updated `EndMeetingBottomSheet` to dynamically display:
  - **End Call / Leave Call** when call terminology is enabled.
  - **End Meeting / Leave Meeting** when meeting terminology is enabled.
- Refactored `RtcViewmodel` to derive configuration values directly from the injected `sdkConfiguration`.
- Centralized configuration management for features such as attachment download behavior and session terminology.
- Updated `PrejoinScreen` to pass the complete `DaakiaMeetingConfiguration` object to `RoomPage`.
- Added documentation for `useCallTerminology`, including usage examples, behavior details, and recommendations for 1:1 call and group meeting experiences.