### PR TITLE
feat: add confirmation dialog to `EndMeetingBottomSheet`

### DIFF
--- a/lib/presentation/bottom_sheets/end_meeting_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/end_meeting_bottomsheet.dart
@@ -15,6 +15,33 @@ class EndMeetingBottomSheet extends StatefulWidget {
 }
 
 class _EndMeetingBottomSheetState extends State<EndMeetingBottomSheet> {
+  Future<void> _confirmEnd() async {
+    final sessionWord = widget.useCallTerminology ? 'call' : 'meeting';
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('End ${sessionWord[0].toUpperCase()}${sessionWord.substring(1)}'),
+        content: Text(
+          'Are you sure you want to end this $sessionWord? This will end it for all participants.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(
+              'End ${sessionWord[0].toUpperCase()}${sessionWord.substring(1)}',
+              style: const TextStyle(color: Colors.red),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) widget.onEndCall();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -34,7 +61,7 @@ class _EndMeetingBottomSheetState extends State<EndMeetingBottomSheet> {
             width: double.infinity,
             height: 60, // Square shape (height equal to width of the button)
             child: ElevatedButton(
-              onPressed: widget.onEndCall,
+              onPressed: _confirmEnd,
               style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.red,
                 shape: RoundedRectangleBorder(


### PR DESCRIPTION
## Summary

This PR adds a confirmation step before ending a session and aligns dialog messaging with the configured meeting or call terminology.

## Changes

- Added `_confirmEnd` flow to display a confirmation dialog before ending a session.
- Updated the primary **End** action to trigger confirmation instead of immediately invoking `onEndCall`.
- Added dynamic dialog content based on the `useCallTerminology` configuration.
- Displays **Call** terminology when `useCallTerminology` is enabled.
- Displays **Meeting** terminology when `useCallTerminology` is disabled.
- Improved user safety by preventing accidental meeting or call termination through an explicit confirmation step.