### PR TITLE
Fix/private chat state management

### DIFF
--- a/lib/presentation/dialog/pariticipant_dialog_controls.dart
+++ b/lib/presentation/dialog/pariticipant_dialog_controls.dart
@@ -172,15 +172,17 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
                 icon: Icons.chat_bubble_outline,
                 text: "Send private message",
                 onTap: () {
-                  // Dismiss the ParticipantDialogControls
+                  widget.viewModel.checkAndCreatePrivateChat(
+                      widget.participant.identity, widget.participant.name);
+                  widget.viewModel.setPrivateChatIdentity(widget.participant.identity);
+                  widget.viewModel.setPrivateChatUserName(widget.participant.name);
+                  // Navigate before dismissing so this context is still valid
+                  showChatBottomSheet(widget.viewModel,
+                      widget.participant.identity, widget.participant.name);
                   Navigator.of(context, rootNavigator: false).pop();
                   if (widget.onDismissBottomSheet != null) {
                     widget.onDismissBottomSheet!();
                   }
-                  widget.viewModel.checkAndCreatePrivateChat(
-                      widget.participant.identity, widget.participant.name);
-                  showChatBottomSheet(widget.viewModel,
-                      widget.participant.identity, widget.participant.name);
                 },
                 isVisible: widget.isForIndividual && (widget.viewModel.meetingDetails.features?.isPrivateChatAllowed() == true),
               ),

--- a/lib/presentation/dialog/pariticipant_dialog_controls.dart
+++ b/lib/presentation/dialog/pariticipant_dialog_controls.dart
@@ -176,13 +176,21 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
                       widget.participant.identity, widget.participant.name);
                   widget.viewModel.setPrivateChatIdentity(widget.participant.identity);
                   widget.viewModel.setPrivateChatUserName(widget.participant.name);
-                  // Navigate before dismissing so this context is still valid
-                  showChatBottomSheet(widget.viewModel,
-                      widget.participant.identity, widget.participant.name);
-                  Navigator.of(context, rootNavigator: false).pop();
+                  // Capture navigator before closing anything — context becomes
+                  // invalid once the dialog is popped.
+                  final navigator = Navigator.of(context);
+                  navigator.pop(); // close this dialog
                   if (widget.onDismissBottomSheet != null) {
-                    widget.onDismissBottomSheet!();
+                    widget.onDismissBottomSheet!(); // close participant page
                   }
+                  navigator.push(MaterialPageRoute<void>(
+                    builder: (_) => ChatController(
+                      identity: widget.participant.identity,
+                      name: widget.participant.name,
+                      viewModel: widget.viewModel,
+                    ),
+                    fullscreenDialog: true,
+                  ));
                 },
                 isVisible: widget.isForIndividual && (widget.viewModel.meetingDetails.features?.isPrivateChatAllowed() == true),
               ),
@@ -325,18 +333,6 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
     return false;
   }
 
-  void showChatBottomSheet(
-      RtcViewmodel viewmodel, String identity, String name) {
-    Navigator.of(context).push(MaterialPageRoute<Null>(
-        builder: (BuildContext context) {
-          return ChatController(
-            identity: identity,
-            name: name,
-            viewModel: viewmodel,
-          );
-        },
-        fullscreenDialog: true));
-  }
 }
 
 class CustomTextItem extends StatelessWidget {

--- a/lib/presentation/pages/private_chat_page.dart
+++ b/lib/presentation/pages/private_chat_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:daakia_vc_flutter_sdk/presentation/widgets/attachment_picker_sheet.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/widgets/initials_circle.dart';
 import 'package:flutter/material.dart';
@@ -26,8 +28,11 @@ class PrivateChatPage extends StatefulWidget {
 }
 
 class PrivateChantState extends State<PrivateChatPage> {
+  StreamSubscription? _privateChatSubscription;
+
   @override
   void dispose() {
+    _privateChatSubscription?.cancel();
     super.dispose();
   }
 
@@ -336,12 +341,9 @@ class PrivateChantState extends State<PrivateChatPage> {
     );
   }
 
-  bool isEventAdded = false;
-
   void collectLobbyEvents(RtcViewmodel? viewModel, BuildContext context) {
-    if (isEventAdded) return;
-    isEventAdded = true;
-    viewModel?.privateChatEvents.listen((event) {
+    if (_privateChatSubscription != null) return;
+    _privateChatSubscription = viewModel?.privateChatEvents.listen((event) {
       if (event is UpdateView) {
         if (mounted) {
           setState(() {});


### PR DESCRIPTION
## Summary

This PR improves private chat initialization, navigation reliability, and event subscription lifecycle management.

## Changes

- Updated private message flow to set the target participant identity and username in the view model before opening the chat screen.
- Refactored private chat navigation to use direct `MaterialPageRoute` navigation instead of `showChatBottomSheet`.
- Fixed navigation context issues by capturing the `NavigatorState` before dismissing the participant dialog.
- Ensured participant action sheets are properly dismissed before navigating to private chat.
- Improved dialog navigation ordering to prevent invalid `BuildContext` usage.
- Replaced the `isEventAdded` flag with a dedicated `StreamSubscription` for private chat event handling.
- Added proper subscription cleanup in `dispose()` to prevent memory leaks and duplicate event listeners.
- Removed the unused `showChatBottomSheet` helper method.