### PR TITLE
Feat/handle duplicate identity detection

### DIFF
--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -19,6 +19,7 @@ import 'package:retrofit/retrofit.dart';
 import '../model/agent_dispatch_data.dart';
 import '../model/base_list_response.dart';
 import '../model/base_response.dart';
+import '../model/meeting_status_model.dart';
 import '../model/event_password_protected_data.dart';
 import '../model/host_controls_data.dart';
 import '../model/host_token_model.dart';
@@ -70,6 +71,12 @@ abstract class RestClient {
   @POST("rtc/meeting/addParticipant/toLobby")
   Future<BaseResponse<RtcData>> addParticipantToLobby(
     @Body() Map<String, dynamic> body,
+  );
+
+  @GET("rtc/meeting/participant/meetingStatus")
+  Future<BaseResponse<MeetingStatusData>> getMeetingStatus(
+    @Header("Authorization") String token,
+    @Query("meeting_uid") String meetingUid,
   );
 
   @POST("saas/sdk/verify/key")

--- a/lib/api/api_client.g.dart
+++ b/lib/api/api_client.g.dart
@@ -249,6 +249,40 @@ class _RestClient implements RestClient {
   }
 
   @override
+  Future<BaseResponse<MeetingStatusData>> getMeetingStatus(
+    String token,
+    String meetingUid,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'meeting_uid': meetingUid};
+    final _headers = <String, dynamic>{r'Authorization': token};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<BaseResponse<MeetingStatusData>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            'rtc/meeting/participant/meetingStatus',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseResponse<MeetingStatusData> _value;
+    try {
+      _value = BaseResponse<MeetingStatusData>.fromJson(
+        _result.data!,
+        (json) => MeetingStatusData.fromJson(json as Map<String, dynamic>),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
   Future<BaseResponse<LicenceVerifyModel>> licenceVerify(
     Map<String, dynamic> body,
   ) async {

--- a/lib/model/meeting_status_model.dart
+++ b/lib/model/meeting_status_model.dart
@@ -17,11 +17,13 @@ class MeetingStatusData {
 class ActiveMeetingItem {
   String? meetingUid;
   String? name;
+  String? platform;
 
-  ActiveMeetingItem({this.meetingUid, this.name});
+  ActiveMeetingItem({this.meetingUid, this.name, this.platform});
 
   ActiveMeetingItem.fromJson(Map<String, dynamic> json) {
     meetingUid = json['meeting_uid'];
     name = json['name'];
+    platform = json['platform'];
   }
 }

--- a/lib/model/meeting_status_model.dart
+++ b/lib/model/meeting_status_model.dart
@@ -1,0 +1,27 @@
+class MeetingStatusData {
+  bool? inMeeting;
+  List<ActiveMeetingItem>? meetings;
+
+  MeetingStatusData({this.inMeeting, this.meetings});
+
+  MeetingStatusData.fromJson(Map<String, dynamic> json) {
+    inMeeting = json['in_meeting'];
+    if (json['meetings'] != null) {
+      meetings = (json['meetings'] as List)
+          .map((e) => ActiveMeetingItem.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+  }
+}
+
+class ActiveMeetingItem {
+  String? meetingUid;
+  String? name;
+
+  ActiveMeetingItem({this.meetingUid, this.name});
+
+  ActiveMeetingItem.fromJson(Map<String, dynamic> json) {
+    meetingUid = json['meeting_uid'];
+    name = json['name'];
+  }
+}

--- a/lib/presentation/bottom_sheets/duplicate_identity_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/duplicate_identity_bottomsheet.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 
 import '../../resources/colors/color.dart';
+import '../../utils/utils.dart';
 
 class DuplicateIdentityBottomSheet extends StatelessWidget {
   final VoidCallback onLeave;
   final VoidCallback onSwitch;
+  final String? otherPlatform;
 
   const DuplicateIdentityBottomSheet({
     required this.onLeave,
     required this.onSwitch,
+    this.otherPlatform,
     super.key,
   });
 
@@ -36,23 +39,15 @@ class DuplicateIdentityBottomSheet extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 24),
-          _DeviceTransferIcon(),
+          _DeviceTransferIcon(otherPlatform: otherPlatform),
           const SizedBox(height: 20),
           const Text(
-            "You're already connected",
+            "You're already connected on\nanother device",
+            textAlign: TextAlign.center,
             style: TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.bold,
               color: Colors.black87,
-            ),
-          ),
-          const SizedBox(height: 10),
-          const Text(
-            "This account is active in the meeting on another device.",
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontSize: 14,
-              color: Colors.black54,
             ),
           ),
           const SizedBox(height: 16),
@@ -70,7 +65,7 @@ class DuplicateIdentityBottomSheet extends StatelessWidget {
                 SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    "Your session on the other device will end when you join here.",
+                    "Switching devices will end your session on the other device.",
                     style: TextStyle(fontSize: 13, color: Colors.black87),
                   ),
                 ),
@@ -124,13 +119,22 @@ class DuplicateIdentityBottomSheet extends StatelessWidget {
 }
 
 class _DeviceTransferIcon extends StatelessWidget {
+  final String? otherPlatform;
+
+  const _DeviceTransferIcon({this.otherPlatform});
+
   @override
   Widget build(BuildContext context) {
+    final otherIcon = _iconForPlatform(otherPlatform);
+    final thisIcon = _iconForPlatform(Utils.getClientPlatform());
+    final otherSize = _isDesktopPlatform(otherPlatform) ? 48.0 : 40.0;
+    final thisSize = _isDesktopPlatform(Utils.getClientPlatform()) ? 48.0 : 40.0;
+
     return Row(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Icon(Icons.laptop_mac, color: themeColor, size: 48),
+        Icon(otherIcon, color: themeColor, size: otherSize),
         const SizedBox(width: 8),
         Row(
           children: List.generate(
@@ -147,8 +151,41 @@ class _DeviceTransferIcon extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 8),
-        Icon(Icons.smartphone, color: themeColor, size: 40),
+        Icon(thisIcon, color: themeColor, size: thisSize),
       ],
     );
+  }
+
+  static IconData _iconForPlatform(String? platform) {
+    switch (platform?.toLowerCase()) {
+      case 'web':
+        return Icons.laptop_mac;
+      case 'macos':
+        return Icons.laptop_mac;
+      case 'windows':
+        return Icons.desktop_windows_outlined;
+      case 'linux':
+        return Icons.computer_outlined;
+      case 'android':
+        return Icons.smartphone;
+      case 'ios':
+        return Icons.phone_iphone;
+      case 'mobile_web':
+        return Icons.smartphone;
+      default:
+        return Icons.devices;
+    }
+  }
+
+  static bool _isDesktopPlatform(String? platform) {
+    switch (platform?.toLowerCase()) {
+      case 'web':
+      case 'macos':
+      case 'windows':
+      case 'linux':
+        return true;
+      default:
+        return false;
+    }
   }
 }

--- a/lib/presentation/bottom_sheets/duplicate_identity_bottomsheet.dart
+++ b/lib/presentation/bottom_sheets/duplicate_identity_bottomsheet.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+
+import '../../resources/colors/color.dart';
+
+class DuplicateIdentityBottomSheet extends StatelessWidget {
+  final VoidCallback onLeave;
+  final VoidCallback onSwitch;
+
+  const DuplicateIdentityBottomSheet({
+    required this.onLeave,
+    required this.onSwitch,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.maxFinite,
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(20),
+          topRight: Radius.circular(20),
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: Colors.grey.shade300,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const SizedBox(height: 24),
+          _DeviceTransferIcon(),
+          const SizedBox(height: 20),
+          const Text(
+            "You're already connected",
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+              color: Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 10),
+          const Text(
+            "This account is active in the meeting on another device.",
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 14,
+              color: Colors.black54,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: const Color(0xFFEFF4FF),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: const Color(0xFFBFD0FF)),
+            ),
+            child: const Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.info_outline, color: themeColor, size: 18),
+                SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    "Your session on the other device will end when you join here.",
+                    style: TextStyle(fontSize: 13, color: Colors.black87),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 20),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: onLeave,
+                  style: OutlinedButton.styleFrom(
+                    side: const BorderSide(color: themeColor),
+                    foregroundColor: themeColor,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  child: const Text(
+                    "Leave this meeting",
+                    style: TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: onSwitch,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: themeColor,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  child: const Text(
+                    "Switch to this device",
+                    style: TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DeviceTransferIcon extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Icon(Icons.laptop_mac, color: themeColor, size: 48),
+        const SizedBox(width: 8),
+        Row(
+          children: List.generate(
+            5,
+            (i) => Container(
+              width: 6,
+              height: 6,
+              margin: const EdgeInsets.symmetric(horizontal: 2),
+              decoration: BoxDecoration(
+                color: themeColor.withAlpha(180 - i * 30),
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Icon(Icons.smartphone, color: themeColor, size: 40),
+      ],
+    );
+  }
+}

--- a/lib/presentation/dialog/duplicate_identity_dialog.dart
+++ b/lib/presentation/dialog/duplicate_identity_dialog.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import '../../resources/colors/color.dart';
+import '../../utils/utils.dart';
+
+class DuplicateIdentityDialog extends StatefulWidget {
+  final VoidCallback onLeave;
+
+  const DuplicateIdentityDialog({required this.onLeave, super.key});
+
+  @override
+  State<DuplicateIdentityDialog> createState() =>
+      _DuplicateIdentityDialogState();
+}
+
+class _DuplicateIdentityDialogState extends State<DuplicateIdentityDialog> {
+  int _countdown = 5;
+  late final Timer _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(seconds: 1), (t) {
+      if (_countdown <= 1) {
+        t.cancel();
+        widget.onLeave();
+      } else {
+        if (mounted) setState(() => _countdown--);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      child: AlertDialog(
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        contentPadding: const EdgeInsets.fromLTRB(24, 28, 24, 0),
+        actionsPadding: const EdgeInsets.fromLTRB(16, 16, 16, 20),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _DeviceIcon(),
+            const SizedBox(height: 20),
+            const Text(
+              "Joined on Another Device",
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: Colors.black87,
+              ),
+            ),
+            const SizedBox(height: 12),
+            const Text(
+              "You have joined this meeting from another device. You will be disconnected from this device.",
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 14,
+                color: Colors.black54,
+                height: 1.5,
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          SizedBox(
+            width: double.maxFinite,
+            child: ElevatedButton(
+              onPressed: widget.onLeave,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: themeColor,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              ),
+              child: Text(
+                "Leave Meeting ($_countdown)",
+                style: const TextStyle(
+                  fontWeight: FontWeight.w600,
+                  fontSize: 15,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DeviceIcon extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final platform = Utils.getClientPlatform();
+    final icon = _iconForPlatform(platform);
+    final iconSize = _isDesktop(platform) ? 40.0 : 36.0;
+
+    return Container(
+      width: 76,
+      height: 76,
+      decoration: BoxDecoration(
+        color: themeColor.withAlpha(20),
+        shape: BoxShape.circle,
+      ),
+      child: Icon(icon, color: themeColor, size: iconSize),
+    );
+  }
+
+  static IconData _iconForPlatform(String? platform) {
+    switch (platform?.toLowerCase()) {
+      case 'web':
+      case 'macos':
+        return Icons.laptop_mac;
+      case 'windows':
+        return Icons.desktop_windows_outlined;
+      case 'linux':
+        return Icons.computer_outlined;
+      case 'android':
+        return Icons.smartphone;
+      case 'ios':
+        return Icons.phone_iphone;
+      default:
+        return Icons.devices;
+    }
+  }
+
+  static bool _isDesktop(String? platform) {
+    return ['web', 'macos', 'windows', 'linux']
+        .contains(platform?.toLowerCase());
+  }
+}

--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -1199,7 +1199,11 @@ class _PreJoinState extends State<PreJoinScreen> {
       apiCall: () => apiClient.getMeetingStatus(token, widget.meetingId),
       onSuccess: (data) {
         if (data?.inMeeting == true) {
-          _showDuplicateDeviceSheet(stopLoading, onProceed);
+          final otherPlatform = data?.meetings?.isNotEmpty == true
+              ? data!.meetings!.first.platform
+              : null;
+          _showDuplicateDeviceSheet(stopLoading, onProceed,
+              otherPlatform: otherPlatform);
         } else {
           onProceed();
         }
@@ -1208,7 +1212,8 @@ class _PreJoinState extends State<PreJoinScreen> {
     );
   }
 
-  void _showDuplicateDeviceSheet(Function stopLoading, VoidCallback onProceed) {
+  void _showDuplicateDeviceSheet(Function stopLoading, VoidCallback onProceed,
+      {String? otherPlatform}) {
     if (!mounted) return;
     showModalBottomSheet<void>(
       context: context,
@@ -1216,6 +1221,7 @@ class _PreJoinState extends State<PreJoinScreen> {
       enableDrag: false,
       backgroundColor: Colors.transparent,
       builder: (_) => DuplicateIdentityBottomSheet(
+        otherPlatform: otherPlatform,
         onLeave: () {
           Navigator.of(context).pop();
           isLoading = false;

--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -18,6 +18,7 @@ import 'package:permission_handler/permission_handler.dart';
 
 import '../../api/injection.dart';
 import '../../model/daakia_meeting_configuration.dart';
+import '../../presentation/bottom_sheets/duplicate_identity_bottomsheet.dart';
 import '../../resources/colors/color.dart';
 import '../../rtc/room.dart';
 import '../../utils/name_input_formatter.dart';
@@ -203,19 +204,20 @@ class _PreJoinState extends State<PreJoinScreen> {
       setState(() {});
     }
 
-    if (widget.isHost && !isHostVerified) {
-      final token = widget.configuration?.vcConfig?.hostToken;
-      if (token != null && token.isNotEmpty) {
-        hostToken = token;
-        isHostVerified = true;
-        getFeaturesAndJoinMeeting(_autoStopLoading);
+    _checkDuplicateJoinAndProceed(_autoStopLoading, () {
+      if (widget.isHost && !isHostVerified) {
+        final token = widget.configuration?.vcConfig?.hostToken;
+        if (token != null && token.isNotEmpty) {
+          hostToken = token;
+          isHostVerified = true;
+          getFeaturesAndJoinMeeting(_autoStopLoading);
+          return;
+        }
+        _getHostToken(_autoStopLoading);
         return;
       }
-      _getHostToken(_autoStopLoading);
-      return;
-    }
-
-    checkMeetingType(_autoStopLoading);
+      checkMeetingType(_autoStopLoading);
+    });
   }
 
   String? _getSkipPreJoinValidationError() {
@@ -1084,28 +1086,30 @@ class _PreJoinState extends State<PreJoinScreen> {
                           return;
                         } else {
                           isNeedToCancelApiCall = false;
-                          if (widget.isHost && !isHostVerified) {
-                            if (!context.mounted) return;
-                            final token =
-                                widget.configuration?.vcConfig?.hostToken;
+                          _checkDuplicateJoinAndProceed(stopLoading, () {
+                            if (widget.isHost && !isHostVerified) {
+                              if (!context.mounted) return;
+                              final token =
+                                  widget.configuration?.vcConfig?.hostToken;
 
-                            if (token != null && token.isNotEmpty) {
-                              hostToken = token;
-                              isHostVerified = true;
-                              isNeedToCancelApiCall = false;
-                              getFeaturesAndJoinMeeting(stopLoading);
-                              return;
-                            }
-                            if (widget.basicMeetingDetails
-                                    ?.hostPinVerificationRequired ==
-                                1) {
-                              _showVerificationDialog(context, stopLoading);
+                              if (token != null && token.isNotEmpty) {
+                                hostToken = token;
+                                isHostVerified = true;
+                                isNeedToCancelApiCall = false;
+                                getFeaturesAndJoinMeeting(stopLoading);
+                                return;
+                              }
+                              if (widget.basicMeetingDetails
+                                      ?.hostPinVerificationRequired ==
+                                  1) {
+                                _showVerificationDialog(context, stopLoading);
+                              } else {
+                                _getHostToken(stopLoading);
+                              }
                             } else {
-                              _getHostToken(stopLoading);
+                              checkMeetingType(stopLoading);
                             }
-                          } else {
-                            checkMeetingType(stopLoading);
-                          }
+                          });
                         }
                       }
                     },
@@ -1186,6 +1190,45 @@ class _PreJoinState extends State<PreJoinScreen> {
     _participantTimer?.cancel();
     _nameController?.dispose();
     super.dispose();
+  }
+
+  void _checkDuplicateJoinAndProceed(
+      Function stopLoading, VoidCallback onProceed) {
+    final token = widget.configuration?.vcConfig?.hostToken ?? hostToken;
+    networkRequestHandler(
+      apiCall: () => apiClient.getMeetingStatus(token, widget.meetingId),
+      onSuccess: (data) {
+        if (data?.inMeeting == true) {
+          _showDuplicateDeviceSheet(stopLoading, onProceed);
+        } else {
+          onProceed();
+        }
+      },
+      onError: (_) => onProceed(),
+    );
+  }
+
+  void _showDuplicateDeviceSheet(Function stopLoading, VoidCallback onProceed) {
+    if (!mounted) return;
+    showModalBottomSheet<void>(
+      context: context,
+      isDismissible: false,
+      enableDrag: false,
+      backgroundColor: Colors.transparent,
+      builder: (_) => DuplicateIdentityBottomSheet(
+        onLeave: () {
+          Navigator.of(context).pop();
+          isLoading = false;
+          isNeedToCancelApiCall = true;
+          stopLoading();
+          if (mounted) setState(() {});
+        },
+        onSwitch: () {
+          Navigator.of(context).pop();
+          onProceed();
+        },
+      ),
+    );
   }
 
   void getFeaturesAndJoinMeeting(Function stopLoading,

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -45,6 +45,7 @@ import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
 import '../model/annotation_stroke.dart';
 import '../model/emoji_message.dart';
 import '../model/remote_activity_data.dart';
+import '../presentation/dialog/duplicate_identity_dialog.dart';
 import '../presentation/dialog/screen_share_request_dialog.dart';
 import '../presentation/pages/transcription_screen.dart';
 import '../utils/consent_status_enum.dart';
@@ -378,14 +379,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
           }
         case DisconnectReason.duplicateIdentity:
           {
-            showSnackBar(message: "You have joined with another device");
-            Timer(const Duration(seconds: 3), () {
-              if (mounted) {
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  closeMeetingProgrammatically(context);
-                });
-              }
-            });
+            _showDuplicateIdentityDialog();
             break;
           }
         case DisconnectReason.roomDeleted:
@@ -1674,6 +1668,19 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         senderName: senderName,
         timestamp: DateTime.now().millisecondsSinceEpoch.toString());
     viewModel.addEmoji(newMessage);
+  }
+
+  void _showDuplicateIdentityDialog() {
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogCtx) => DuplicateIdentityDialog(
+        onLeave: () {
+          Navigator.of(dialogCtx).pop();
+          closeMeetingProgrammatically(context);
+        },
+      ),
+    );
   }
 
   // When closing the meeting programmatically


### PR DESCRIPTION
## Summary

This PR adds duplicate identity detection and handling for multi-device sessions, improving the meeting join experience and session management.

## Changes

- Added `MeetingStatusData` and `ActiveMeetingItem` models for meeting status responses.
- Added `getMeetingStatus` API endpoint to check a participant's active meeting sessions.
- Implemented duplicate identity verification in `PreJoinScreen` before joining a meeting.
- Added `DuplicateIdentityBottomSheet` to allow users to either switch the active session to the current device or leave the existing session.
- Enhanced duplicate identity UI with platform-specific device icons and current/active device information.
- Added `platform` support to `ActiveMeetingItem` for accurate device identification.
- Introduced `DuplicateIdentityDialog` to notify users when they join from another device during an active session.
- Added a non-dismissible dialog with a 5-second countdown and automatic leave behavior.
- Replaced the duplicate identity snackbar with a modal dialog to ensure user acknowledgment before closing the meeting.