### PR TITLE
Feat/participant-quick-actions-improvement

### DIFF
--- a/lib/presentation/dialog/pariticipant_dialog_controls.dart
+++ b/lib/presentation/dialog/pariticipant_dialog_controls.dart
@@ -90,7 +90,7 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
                 ),
               CustomTextItem(
                 icon: Icons.mic_off,
-                text: "Mute All",
+                text: "Mute all",
                 onTap: () {
                   Navigator.pop(context);
                   widget.viewModel.sendAction(ActionModel(action: MeetingActions.muteMic));
@@ -99,7 +99,7 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
               ),
               CustomTextItem(
                 icon: Icons.videocam_off,
-                text: "Video Off All",
+                text: "Video off all",
                 onTap: () {
                   Navigator.pop(context);
                   widget.viewModel

--- a/lib/presentation/dialog/pariticipant_dialog_controls.dart
+++ b/lib/presentation/dialog/pariticipant_dialog_controls.dart
@@ -1,10 +1,9 @@
-import 'package:daakia_vc_flutter_sdk/events/rtc_events.dart';
 import 'package:flutter/material.dart';
 import 'package:livekit_client/livekit_client.dart';
 
 import '../../model/action_model.dart';
 import '../../utils/meeting_actions.dart';
-import '../../utils/utils.dart';
+import '../../utils/participant_action_specs.dart';
 import '../../viewmodel/rtc_viewmodel.dart';
 import '../pages/chat_controller.dart';
 
@@ -37,16 +36,34 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
   }
 
   Widget _buildDialog(BuildContext context) {
-    String? myRoleMataData = widget.viewModel.room.localParticipant?.metadata;
-    String? targetRoleMataData = widget.participant.metadata;
-    final bool micOn = widget.participant.isMicrophoneEnabled();
-    final bool cameraOn = widget.participant.isCameraEnabled();
-    final bool micPermissionGranted = Utils.isMicEnabled(widget.participant.attributes);
-    final bool videoPermissionGranted = Utils.isVideoEnabled(widget.participant.attributes);
-    final bool isCoHost = Utils.isCoHost(widget.participant.metadata);
-    final bool isPinned = widget.viewModel.pinnedParticipantId == widget.participant.identity;
-    final bool annotationPermissionGranted = Utils.isAnnotationAllowed(widget.participant.attributes);
-    final bool targetIsOnMobile = Utils.isMobilePlatform(widget.participant.metadata);
+    final actions = buildParticipantActionSpecs(
+      participant: widget.participant,
+      viewModel: widget.viewModel,
+      onDismiss: () => Navigator.pop(context),
+      onRename: () {
+        Navigator.pop(context);
+        showParticipantRenameDialog(
+            context, widget.participant, widget.viewModel);
+      },
+      onOpenPrivateChat: () {
+        // Capture navigator before closing anything — context becomes
+        // invalid once the dialog is popped.
+        final navigator = Navigator.of(context);
+        navigator.pop(); // close this dialog
+        if (widget.onDismissBottomSheet != null) {
+          widget.onDismissBottomSheet!(); // close participant page
+        }
+        navigator.push(MaterialPageRoute<void>(
+          builder: (_) => ChatController(
+            identity: widget.participant.identity,
+            name: widget.participant.name,
+            viewModel: widget.viewModel,
+          ),
+          fullscreenDialog: true,
+        ));
+      },
+      onAnnotationUnavailable: () => showAnnotationUnavailableDialog(context),
+    );
 
     return Dialog(
       shape: RoundedRectangleBorder(
@@ -64,151 +81,13 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              CustomTextItem(
-                icon: micOn ? Icons.mic_off : Icons.mic,
-                text: micOn ? "Mute Mic" : "Ask To Unmute Mic",
-                onTap: () {
-                  Navigator.pop(context);
-                  widget.viewModel.sendPrivateAction(
-                      ActionModel(
-                          action: micOn
-                              ? MeetingActions.muteMic
-                              : MeetingActions.askToUnmuteMic),
-                      widget.participant.identity);
-                },
-                isVisible: (widget.isForIndividual &&
-                    (!widget.viewModel.isAudioModeEnable || micOn) &&
-                    (Utils.isHost(myRoleMataData) ||
-                        Utils.isCoHost(myRoleMataData))),
-              ),
-              CustomTextItem(
-                icon: cameraOn ? Icons.videocam_off : Icons.videocam,
-                text: cameraOn ? "Turn Off Camera" : "Ask To Turn ON Camera",
-                onTap: () {
-                  Navigator.pop(context);
-                  widget.viewModel.sendPrivateAction(
-                      ActionModel(
-                          action: cameraOn
-                              ? MeetingActions.muteCamera
-                              : MeetingActions.askToUnmuteCamera),
-                      widget.participant.identity);
-                },
-                isVisible: (widget.isForIndividual &&
-                    (!widget.viewModel.isVideoModeEnable || cameraOn) &&
-                    (Utils.isHost(myRoleMataData) ||
-                        Utils.isCoHost(myRoleMataData))),
-              ),
-              CustomTextItem(
-                icon: micPermissionGranted ? Icons.mic_off : Icons.mic,
-                text: micPermissionGranted
-                    ? "Revoke Mic Permission"
-                    : "Allow Mic Permission",
-                onTap: () {
-                  Navigator.pop(context);
-                  widget.viewModel.updateAudioPermissionForParticipant(
-                      widget.participant.identity, !micPermissionGranted);
-                },
-                isVisible: (widget.isForIndividual && widget.viewModel.isAudioModeEnable &&
-                    (!Utils.isHost(targetRoleMataData) && !Utils.isCoHost(targetRoleMataData)) &&
-                    (Utils.isHost(myRoleMataData) ||
-                        Utils.isCoHost(myRoleMataData))),
-              ),
-              CustomTextItem(
-                icon: videoPermissionGranted ? Icons.videocam_off : Icons.videocam,
-                text: videoPermissionGranted
-                    ? "Revoke Video Permission"
-                    : "Allow Video Permission",
-                onTap: () {
-                  Navigator.pop(context);
-                  widget.viewModel.updateVideoPermissionForParticipant(
-                      widget.participant.identity, !videoPermissionGranted);
-                },
-                isVisible: (widget.isForIndividual && widget.viewModel.isVideoModeEnable &&
-                    (!Utils.isHost(targetRoleMataData) && !Utils.isCoHost(targetRoleMataData)) &&
-                    (Utils.isHost(myRoleMataData) ||
-                        Utils.isCoHost(myRoleMataData))),
-              ),
-              CustomTextItem(
-                icon: annotationPermissionGranted ? Icons.draw : Icons.draw_outlined,
-                text: annotationPermissionGranted
-                    ? "Revoke Annotation Permission"
-                    : "Allow Annotation Permission",
-                onTap: () {
-                  Navigator.pop(context);
-                  if (targetIsOnMobile) {
-                    _showAnnotationUnavailableDialog(context);
-                    return;
-                  }
-                  widget.viewModel.updateAnnotationPermissionForParticipant(
-                      widget.participant.identity, !annotationPermissionGranted);
-                },
-                isVisible: widget.isForIndividual &&
-                    widget.viewModel.isAnnotationEnabled &&
-                    (!Utils.isHost(targetRoleMataData) && !Utils.isCoHost(targetRoleMataData)) &&
-                    (Utils.isHost(myRoleMataData) || Utils.isCoHost(myRoleMataData)),
-              ),
-              CustomTextItem(
-                icon: isCoHost ? Icons.remove_moderator : Icons.admin_panel_settings,
-                text: isCoHost ? "Remove Co-Host" : "Make Co-Host",
-                onTap: () {
-                  Navigator.pop(context);
-                  widget.viewModel.makeCoHost(widget.participant.identity, !isCoHost);
-                },
-                isVisible: (widget.isForIndividual && isCoHostButtonEnable()),
-              ),
-              CustomTextItem(
-                icon: Icons.person_remove,
-                text: "Remove From Call",
-                onTap: () {
-                  Navigator.pop(context);
-                  widget.viewModel.removeFromCall(widget.participant.identity);
-                },
-                isVisible: (widget.isForIndividual &&
-                    (Utils.isHost(myRoleMataData) ||
-                        (Utils.isCoHost(myRoleMataData) &&
-                            !Utils.isHost(targetRoleMataData)))),
-              ),
-              CustomTextItem(
-                icon: Icons.chat_bubble_outline,
-                text: "Send private message",
-                onTap: () {
-                  widget.viewModel.checkAndCreatePrivateChat(
-                      widget.participant.identity, widget.participant.name);
-                  widget.viewModel.setPrivateChatIdentity(widget.participant.identity);
-                  widget.viewModel.setPrivateChatUserName(widget.participant.name);
-                  // Capture navigator before closing anything — context becomes
-                  // invalid once the dialog is popped.
-                  final navigator = Navigator.of(context);
-                  navigator.pop(); // close this dialog
-                  if (widget.onDismissBottomSheet != null) {
-                    widget.onDismissBottomSheet!(); // close participant page
-                  }
-                  navigator.push(MaterialPageRoute<void>(
-                    builder: (_) => ChatController(
-                      identity: widget.participant.identity,
-                      name: widget.participant.name,
-                      viewModel: widget.viewModel,
-                    ),
-                    fullscreenDialog: true,
-                  ));
-                },
-                isVisible: widget.isForIndividual && (widget.viewModel.meetingDetails.features?.isPrivateChatAllowed() == true),
-              ),
-              CustomTextItem(
-                icon: isPinned ? Icons.push_pin_outlined : Icons.push_pin,
-                text: isPinned ? "Unpin" : "Pin to screen",
-                onTap: () {
-                  // Dismiss the ParticipantDialogControls
-                  Navigator.of(context, rootNavigator: false).pop();
-                  if (isPinned) {
-                    widget.viewModel.pinnedParticipantId = null;
-                  } else {
-                    widget.viewModel.pinnedParticipantId = widget.participant.identity;
-                  }
-                  widget.viewModel.sendEvent(SortParticipants());
-                },
-                isVisible: widget.isForIndividual,
-              ),
+              for (final action in actions)
+                CustomTextItem(
+                  icon: action.icon,
+                  text: action.label,
+                  onTap: action.onTap,
+                  isVisible: widget.isForIndividual && action.visible,
+                ),
               CustomTextItem(
                 icon: Icons.mic_off,
                 text: "Mute All",
@@ -247,92 +126,6 @@ class ParticipantDialogState extends State<ParticipantDialogControls> {
       ),
     );
   }
-
-  void _showAnnotationUnavailableDialog(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (ctx) => Dialog(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        backgroundColor: Colors.white,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                width: 52,
-                height: 52,
-                decoration: const BoxDecoration(
-                  color: Color(0xFFECECF8),
-                  shape: BoxShape.circle,
-                ),
-                child: const Icon(Icons.draw_outlined, color: Color(0xFF7B7BED), size: 24),
-              ),
-              const SizedBox(height: 16),
-              const Text(
-                "Annotation Unavailable",
-                style: TextStyle(fontSize: 17, fontWeight: FontWeight.bold, color: Colors.black87),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 10),
-              const Text(
-                "This Participant is using a mobile device. Annotation is available only on desktop/laptop device.",
-                style: TextStyle(fontSize: 14, color: Colors.black54, height: 1.4),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 22),
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  onPressed: () => Navigator.of(ctx).pop(),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF7B7BED),
-                    foregroundColor: Colors.white,
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-                    padding: const EdgeInsets.symmetric(vertical: 14),
-                    elevation: 0,
-                  ),
-                  child: const Text("Got it", style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600)),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  bool isCoHostButtonEnable() {
-    final String? myMetadata = widget.viewModel.room.localParticipant?.metadata;
-    final String? targetMetadata = widget.participant.metadata;
-
-    final bool amIHost = Utils.isHost(myMetadata);
-    final bool amICoHost = Utils.isCoHost(myMetadata);
-
-    final bool isTargetHost = Utils.isHost(targetMetadata);
-    final bool isTargetCoHost = Utils.isCoHost(targetMetadata);
-    final bool isTargetGuest = !isTargetHost && !isTargetCoHost;
-
-    // ❌ Cannot modify the Host
-    if (isTargetHost) return false;
-
-    // ✅ Host or Co-Host can demote a Co-Host
-    if ((amIHost || amICoHost) && isTargetCoHost) return true;
-
-    // ✅ Host or Co-Host can promote a Guest to Co-Host
-    if ((amIHost || amICoHost) && isTargetGuest) {
-      final allowMultiple = widget.viewModel.meetingDetails.features?.isAllowMultipleCoHost() == true;
-      if (allowMultiple) {
-        return true;
-      } else {
-        return widget.viewModel.coHostCount < 1;
-      }
-    }
-
-    // ❌ In all other cases
-    return false;
-  }
-
 }
 
 class CustomTextItem extends StatelessWidget {

--- a/lib/rtc/widgets/participant_quick_actions.dart
+++ b/lib/rtc/widgets/participant_quick_actions.dart
@@ -62,6 +62,8 @@ class _ParticipantQuickActionsSheetState
 
     final bool isTargetHost = Utils.isHost(participant.metadata);
     final bool isTargetCoHost = Utils.isCoHost(participant.metadata);
+    final bool isSelf =
+        participant.identity == viewModel.room.localParticipant?.identity;
 
     final actions = buildParticipantActionSpecs(
       participant: participant,
@@ -143,15 +145,44 @@ class _ParticipantQuickActionsSheetState
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          displayName,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 16,
-                            fontWeight: FontWeight.w600,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                        Row(
+                          children: [
+                            Flexible(
+                              child: Text(
+                                displayName,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            // Surfaced explicitly so a host isn't confused
+                            // about why fewer actions show up when they open
+                            // this sheet on their own tile — most actions
+                            // only apply to remote participants.
+                            if (isSelf) ...[
+                              const SizedBox(width: 6),
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 8, vertical: 2),
+                                decoration: BoxDecoration(
+                                  color: Colors.white24,
+                                  borderRadius: BorderRadius.circular(10),
+                                ),
+                                child: const Text(
+                                  'You',
+                                  style: TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 11,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ],
                         ),
                         if (roleLabel.isNotEmpty)
                           Text(

--- a/lib/rtc/widgets/participant_quick_actions.dart
+++ b/lib/rtc/widgets/participant_quick_actions.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:livekit_client/livekit_client.dart';
 
-import '../../events/rtc_events.dart';
-import '../../model/action_model.dart';
 import '../../presentation/pages/chat_controller.dart';
-import '../../utils/meeting_actions.dart';
+import '../../utils/participant_action_specs.dart';
 import '../../utils/utils.dart';
 import '../../viewmodel/rtc_viewmodel.dart';
 
@@ -62,63 +60,38 @@ class _ParticipantQuickActionsSheetState
     final participant = widget.participant;
     final viewModel = widget.viewModel;
 
-    final bool isSelf =
-        participant.identity == viewModel.room.localParticipant?.identity;
-    final bool isRemote = !isSelf;
+    final bool isTargetHost = Utils.isHost(participant.metadata);
+    final bool isTargetCoHost = Utils.isCoHost(participant.metadata);
 
-    final String? myMetadata = viewModel.room.localParticipant?.metadata;
-    final String? targetMetadata = participant.metadata;
-
-    final bool amIHost = Utils.isHost(myMetadata);
-    final bool amICoHost = Utils.isCoHost(myMetadata);
-    final bool isTargetHost = Utils.isHost(targetMetadata);
-    final bool isTargetCoHost = Utils.isCoHost(targetMetadata);
-
-    final bool micOn = participant.isMicrophoneEnabled();
-    final bool cameraOn = participant.isCameraEnabled();
-    final bool micPermGranted = Utils.isMicEnabled(participant.attributes);
-    final bool videoPermGranted = Utils.isVideoEnabled(participant.attributes);
-    final bool isPinned =
-        viewModel.pinnedParticipantId == participant.identity;
-
-    // ── Visibility guards (mirrors pariticipant_dialog_controls.dart logic) ──
-
-    // Rename: self if self-edit allowed; remote if host/cohost + host-edit allowed
-    final bool canRename = isSelf
-        ? viewModel.meetingDetails.features?.isProfileEditBySelfAllowed() == true
-        : (amIHost || amICoHost) &&
-            viewModel.meetingDetails.features?.isProfileEditByHostAllowed() ==
-                true;
-
-    // Private message: remote only, feature-gated
-    final bool canPrivateChat = isRemote &&
-        viewModel.meetingDetails.features?.isPrivateChatAllowed() == true;
-
-    // Mic direct control: remote, host/cohost; restricted to mute-only when
-    // audio permission mode is active (same rule as the dialog)
-    final bool showMicControl = isRemote &&
-        (amIHost || amICoHost) &&
-        (!viewModel.isAudioModeEnable || micOn);
-
-    // Camera direct control: remote, host/cohost; restricted to turn-off-only
-    // when video permission mode is active
-    final bool showCameraControl = isRemote &&
-        (amIHost || amICoHost) &&
-        (!viewModel.isVideoModeEnable || cameraOn);
-
-    // Allow / Revoke mic permission (workshop audio mode)
-    final bool showMicPermission = isRemote &&
-        viewModel.isAudioModeEnable &&
-        !isTargetHost &&
-        !isTargetCoHost &&
-        (amIHost || amICoHost);
-
-    // Allow / Revoke video permission (workshop video mode)
-    final bool showVideoPermission = isRemote &&
-        viewModel.isVideoModeEnable &&
-        !isTargetHost &&
-        !isTargetCoHost &&
-        (amIHost || amICoHost);
+    final actions = buildParticipantActionSpecs(
+      participant: participant,
+      viewModel: viewModel,
+      onDismiss: () => Navigator.pop(context),
+      onRename: () {
+        Navigator.pop(context);
+        // Use the root navigator's context: the sheet is already dismissed
+        // at this point, so the builder's `context` param may be unmounted.
+        showParticipantRenameDialog(
+            Navigator.of(this.context, rootNavigator: false).context,
+            participant,
+            viewModel);
+      },
+      onOpenPrivateChat: () {
+        Navigator.pop(context);
+        widget.onNavigateTo(
+          MaterialPageRoute(
+            builder: (_) => ChatController(
+              identity: participant.identity,
+              name: participant.name,
+              viewModel: viewModel,
+            ),
+            fullscreenDialog: true,
+          ),
+        );
+      },
+      onAnnotationUnavailable: () => showAnnotationUnavailableDialog(
+          Navigator.of(this.context, rootNavigator: false).context),
+    );
 
     final String displayName = participant.name.isNotEmpty
         ? participant.name
@@ -199,142 +172,17 @@ class _ParticipantQuickActionsSheetState
             const SizedBox(height: 4),
 
             // ── Actions ─────────────────────────────────────────────────────
-
-            _ActionTile(
-              icon: Icons.edit_outlined,
-              label: 'Rename',
-              visible: canRename,
-              onTap: () {
-                Navigator.pop(context);
-                _showRenameDialog(participant, viewModel);
-              },
-            ),
-            _ActionTile(
-              icon: isPinned ? Icons.push_pin_outlined : Icons.push_pin,
-              label: isPinned ? 'Unpin' : 'Pin to screen',
-              visible: true,
-              onTap: () {
-                Navigator.pop(context);
-                viewModel.pinnedParticipantId =
-                    isPinned ? null : participant.identity;
-                viewModel.sendEvent(SortParticipants());
-              },
-            ),
-            _ActionTile(
-              icon: Icons.chat_bubble_outline,
-              label: 'Send private message',
-              visible: canPrivateChat,
-              onTap: () {
-                Navigator.pop(context);
-                viewModel.checkAndCreatePrivateChat(
-                    participant.identity, participant.name);
-                widget.onNavigateTo(
-                  MaterialPageRoute(
-                    builder: (_) => ChatController(
-                      identity: participant.identity,
-                      name: participant.name,
-                      viewModel: viewModel,
-                    ),
-                    fullscreenDialog: true,
-                  ),
-                );
-              },
-            ),
-            _ActionTile(
-              icon: micOn ? Icons.mic_off : Icons.mic,
-              label: micOn ? 'Mute Mic' : 'Ask To Unmute Mic',
-              visible: showMicControl,
-              onTap: () {
-                Navigator.pop(context);
-                viewModel.sendPrivateAction(
-                  ActionModel(
-                    action: micOn
-                        ? MeetingActions.muteMic
-                        : MeetingActions.askToUnmuteMic,
-                  ),
-                  participant.identity,
-                );
-              },
-            ),
-            _ActionTile(
-              icon: cameraOn ? Icons.videocam_off : Icons.videocam,
-              label: cameraOn ? 'Turn Off Camera' : 'Ask To Turn ON Camera',
-              visible: showCameraControl,
-              onTap: () {
-                Navigator.pop(context);
-                viewModel.sendPrivateAction(
-                  ActionModel(
-                    action: cameraOn
-                        ? MeetingActions.muteCamera
-                        : MeetingActions.askToUnmuteCamera,
-                  ),
-                  participant.identity,
-                );
-              },
-            ),
-            _ActionTile(
-              icon: micPermGranted ? Icons.mic_off : Icons.mic,
-              label: micPermGranted
-                  ? 'Revoke Mic Permission'
-                  : 'Allow Mic Permission',
-              visible: showMicPermission,
-              onTap: () {
-                Navigator.pop(context);
-                viewModel.updateAudioPermissionForParticipant(
-                    participant.identity, !micPermGranted);
-              },
-            ),
-            _ActionTile(
-              icon: videoPermGranted ? Icons.videocam_off : Icons.videocam,
-              label: videoPermGranted
-                  ? 'Revoke Video Permission'
-                  : 'Allow Video Permission',
-              visible: showVideoPermission,
-              onTap: () {
-                Navigator.pop(context);
-                viewModel.updateVideoPermissionForParticipant(
-                    participant.identity, !videoPermGranted);
-              },
-            ),
+            for (final action in actions)
+              _ActionTile(
+                icon: action.icon,
+                label: action.label,
+                visible: action.visible,
+                onTap: action.onTap,
+              ),
 
             const SizedBox(height: 8),
           ],
         ),
-      ),
-    );
-  }
-
-  void _showRenameDialog(Participant participant, RtcViewmodel viewModel) {
-    final controller = TextEditingController(text: participant.name);
-    // Use root context since the sheet is already dismissed at this point
-    final ctx = Navigator.of(context, rootNavigator: false).context;
-    showDialog(
-      context: ctx,
-      builder: (dialogCtx) => AlertDialog(
-        title: const Text('Rename'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          textCapitalization: TextCapitalization.words,
-          decoration: const InputDecoration(labelText: 'Enter new name'),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogCtx),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () {
-              final newName = controller.text.trim();
-              if (newName.isNotEmpty) {
-                viewModel.updateParticipantName(
-                    participant: participant.identity, newName: newName);
-              }
-              Navigator.pop(dialogCtx);
-            },
-            child: const Text('Save'),
-          ),
-        ],
       ),
     );
   }

--- a/lib/utils/participant_action_specs.dart
+++ b/lib/utils/participant_action_specs.dart
@@ -1,0 +1,348 @@
+import 'package:flutter/material.dart';
+import 'package:livekit_client/livekit_client.dart';
+
+import '../events/rtc_events.dart';
+import '../model/action_model.dart';
+import '../viewmodel/rtc_viewmodel.dart';
+import 'meeting_actions.dart';
+import 'utils.dart';
+
+/// One row in a participant actions menu (quick-actions sheet, participant
+/// dialog, ...).
+class ParticipantActionSpec {
+  final IconData icon;
+  final String label;
+  final bool visible;
+  final VoidCallback onTap;
+
+  const ParticipantActionSpec({
+    required this.icon,
+    required this.label,
+    required this.visible,
+    required this.onTap,
+  });
+}
+
+/// Canonical list of per-participant actions (rename, pin, private message,
+/// mic/camera control, permissions, co-host, remove...) shared by every
+/// surface that shows individual participant controls. Add new
+/// individual-participant actions here once so every surface picks them up —
+/// do not re-implement this logic per surface.
+///
+/// [onDismiss] closes the caller's menu/sheet before a simple viewmodel
+/// action runs. [onRename] and [onOpenPrivateChat] are left to the caller
+/// because they need to dismiss the menu and then open another dialog/route,
+/// and the correct sequencing differs depending on what else the caller's
+/// screen needs to close first.
+List<ParticipantActionSpec> buildParticipantActionSpecs({
+  required Participant participant,
+  required RtcViewmodel viewModel,
+  required VoidCallback onDismiss,
+  required VoidCallback onRename,
+  required VoidCallback onOpenPrivateChat,
+  required VoidCallback onAnnotationUnavailable,
+}) {
+  final String? myMetadata = viewModel.room.localParticipant?.metadata;
+  final String? targetMetadata = participant.metadata;
+
+  final bool amIHost = Utils.isHost(myMetadata);
+  final bool amICoHost = Utils.isCoHost(myMetadata);
+  final bool isTargetHost = Utils.isHost(targetMetadata);
+  final bool isTargetCoHost = Utils.isCoHost(targetMetadata);
+  final bool isTargetGuest = !isTargetHost && !isTargetCoHost;
+
+  final bool isSelf =
+      participant.identity == viewModel.room.localParticipant?.identity;
+  final bool isRemote = !isSelf;
+
+  final bool micOn = participant.isMicrophoneEnabled();
+  final bool cameraOn = participant.isCameraEnabled();
+  final bool micPermGranted = Utils.isMicEnabled(participant.attributes);
+  final bool videoPermGranted = Utils.isVideoEnabled(participant.attributes);
+  final bool annotationPermGranted =
+      Utils.isAnnotationAllowed(participant.attributes);
+  final bool targetIsOnMobile = Utils.isMobilePlatform(participant.metadata);
+  final bool isPinned = viewModel.pinnedParticipantId == participant.identity;
+  final bool isHandRaised = viewModel.raisedHandQueue
+      .any((raisedHand) => raisedHand.identity == participant.identity);
+
+  bool canToggleCoHost() {
+    // Host can never be demoted/promoted from this menu.
+    if (isTargetHost) return false;
+
+    // Host or co-host can demote an existing co-host.
+    if ((amIHost || amICoHost) && isTargetCoHost) return true;
+
+    // Host or co-host can promote a guest, subject to the multi-co-host
+    // feature flag / current co-host count.
+    if ((amIHost || amICoHost) && isTargetGuest) {
+      final allowMultiple =
+          viewModel.meetingDetails.features?.isAllowMultipleCoHost() == true;
+      return allowMultiple || viewModel.coHostCount < 1;
+    }
+
+    return false;
+  }
+
+  // Order matches the web client's participant actions menu, agreed with
+  // the web team, so hosts see the same layout on every platform. Mic/camera
+  // direct control have no web equivalent (web only exposes the permission
+  // toggles here) so they're placed right next to their matching permission
+  // action.
+  return [
+    ParticipantActionSpec(
+      icon: micPermGranted ? Icons.mic_off : Icons.mic,
+      label:
+          micPermGranted ? 'Revoke Mic Permission' : 'Allow Mic Permission',
+      visible: isRemote &&
+          viewModel.isAudioModeEnable &&
+          !isTargetHost &&
+          !isTargetCoHost &&
+          (amIHost || amICoHost),
+      onTap: () {
+        onDismiss();
+        viewModel.updateAudioPermissionForParticipant(
+            participant.identity, !micPermGranted);
+      },
+    ),
+    ParticipantActionSpec(
+      icon: micOn ? Icons.mic_off : Icons.mic,
+      label: micOn ? 'Mute Mic' : 'Ask To Unmute Mic',
+      visible: isRemote &&
+          (amIHost || amICoHost) &&
+          (!viewModel.isAudioModeEnable || micOn),
+      onTap: () {
+        onDismiss();
+        viewModel.sendPrivateAction(
+          ActionModel(
+            action:
+                micOn ? MeetingActions.muteMic : MeetingActions.askToUnmuteMic,
+          ),
+          participant.identity,
+        );
+      },
+    ),
+    ParticipantActionSpec(
+      icon: videoPermGranted ? Icons.videocam_off : Icons.videocam,
+      label: videoPermGranted
+          ? 'Revoke Video Permission'
+          : 'Allow Video Permission',
+      visible: isRemote &&
+          viewModel.isVideoModeEnable &&
+          !isTargetHost &&
+          !isTargetCoHost &&
+          (amIHost || amICoHost),
+      onTap: () {
+        onDismiss();
+        viewModel.updateVideoPermissionForParticipant(
+            participant.identity, !videoPermGranted);
+      },
+    ),
+    ParticipantActionSpec(
+      icon: cameraOn ? Icons.videocam_off : Icons.videocam,
+      label: cameraOn ? 'Turn Off Camera' : 'Ask To Turn ON Camera',
+      visible: isRemote &&
+          (amIHost || amICoHost) &&
+          (!viewModel.isVideoModeEnable || cameraOn),
+      onTap: () {
+        onDismiss();
+        viewModel.sendPrivateAction(
+          ActionModel(
+            action: cameraOn
+                ? MeetingActions.muteCamera
+                : MeetingActions.askToUnmuteCamera,
+          ),
+          participant.identity,
+        );
+      },
+    ),
+    ParticipantActionSpec(
+      icon: annotationPermGranted ? Icons.draw : Icons.draw_outlined,
+      label: annotationPermGranted
+          ? 'Revoke Annotation Permission'
+          : 'Allow to Annotate',
+      visible: isRemote &&
+          viewModel.isAnnotationEnabled &&
+          !isTargetHost &&
+          !isTargetCoHost &&
+          (amIHost || amICoHost),
+      onTap: () {
+        onDismiss();
+        if (targetIsOnMobile) {
+          onAnnotationUnavailable();
+          return;
+        }
+        viewModel.updateAnnotationPermissionForParticipant(
+            participant.identity, !annotationPermGranted);
+      },
+    ),
+    ParticipantActionSpec(
+      icon: Icons.edit_outlined,
+      label: 'Rename',
+      visible: isSelf
+          ? viewModel.meetingDetails.features?.isProfileEditBySelfAllowed() ==
+              true
+          : (amIHost || amICoHost) &&
+              viewModel.meetingDetails.features?.isProfileEditByHostAllowed() ==
+                  true,
+      onTap: onRename,
+    ),
+    ParticipantActionSpec(
+      icon:
+          isTargetCoHost ? Icons.remove_moderator : Icons.admin_panel_settings,
+      label: isTargetCoHost ? 'Remove Co-Host' : 'Make Co-Host',
+      visible: isRemote && canToggleCoHost(),
+      onTap: () {
+        onDismiss();
+        viewModel.makeCoHost(participant.identity, !isTargetCoHost);
+      },
+    ),
+    ParticipantActionSpec(
+      icon: Icons.front_hand_outlined,
+      label: 'Lower Hand',
+      visible: isRemote &&
+          isHandRaised &&
+          (amIHost || amICoHost) &&
+          viewModel.meetingDetails.features?.isRaiseHandAllowed() == true,
+      onTap: () {
+        onDismiss();
+        viewModel.lowerHand(participant.identity);
+      },
+    ),
+    ParticipantActionSpec(
+      icon: isPinned ? Icons.push_pin_outlined : Icons.push_pin,
+      label: isPinned ? 'Unpin' : 'Pin to screen',
+      visible: true,
+      onTap: () {
+        onDismiss();
+        viewModel.pinnedParticipantId =
+            isPinned ? null : participant.identity;
+        viewModel.sendEvent(SortParticipants());
+      },
+    ),
+    ParticipantActionSpec(
+      icon: Icons.person_remove,
+      label: 'Remove From Call',
+      visible: isRemote && (amIHost || (amICoHost && !isTargetHost)),
+      onTap: () {
+        onDismiss();
+        viewModel.removeFromCall(participant.identity);
+      },
+    ),
+    ParticipantActionSpec(
+      icon: Icons.chat_bubble_outline,
+      label: 'Send private message',
+      visible: isRemote &&
+          viewModel.meetingDetails.features?.isPrivateChatAllowed() == true,
+      onTap: () {
+        viewModel.checkAndCreatePrivateChat(
+            participant.identity, participant.name);
+        viewModel.setPrivateChatIdentity(participant.identity);
+        viewModel.setPrivateChatUserName(participant.name);
+        onOpenPrivateChat();
+      },
+    ),
+  ];
+}
+
+/// Shared "Rename participant" dialog, used by every surface that exposes
+/// the Rename action from [buildParticipantActionSpecs].
+void showParticipantRenameDialog(
+  BuildContext context,
+  Participant participant,
+  RtcViewmodel viewModel,
+) {
+  final controller = TextEditingController(text: participant.name);
+  showDialog(
+    context: context,
+    builder: (dialogCtx) => AlertDialog(
+      title: const Text('Rename'),
+      content: TextField(
+        controller: controller,
+        autofocus: true,
+        textCapitalization: TextCapitalization.words,
+        decoration: const InputDecoration(labelText: 'Enter new name'),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(dialogCtx),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () {
+            final newName = controller.text.trim();
+            if (newName.isNotEmpty) {
+              viewModel.updateParticipantName(
+                  participant: participant.identity, newName: newName);
+            }
+            Navigator.pop(dialogCtx);
+          },
+          child: const Text('Save'),
+        ),
+      ],
+    ),
+  );
+}
+
+/// Shared "Annotation unavailable on mobile" dialog, used by every surface
+/// that exposes the Annotation Permission action from
+/// [buildParticipantActionSpecs].
+void showAnnotationUnavailableDialog(BuildContext context) {
+  showDialog(
+    context: context,
+    builder: (ctx) => Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      backgroundColor: Colors.white,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 28, 24, 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 52,
+              height: 52,
+              decoration: const BoxDecoration(
+                color: Color(0xFFECECF8),
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(Icons.draw_outlined,
+                  color: Color(0xFF7B7BED), size: 24),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              "Annotation Unavailable",
+              style: TextStyle(
+                  fontSize: 17,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black87),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 10),
+            const Text(
+              "This Participant is using a mobile device. Annotation is available only on desktop/laptop device.",
+              style: TextStyle(fontSize: 14, color: Colors.black54, height: 1.4),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 22),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () => Navigator.of(ctx).pop(),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF7B7BED),
+                  foregroundColor: Colors.white,
+                  shape:
+                      RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  elevation: 0,
+                ),
+                child: const Text("Got it",
+                    style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/utils/participant_action_specs.dart
+++ b/lib/utils/participant_action_specs.dart
@@ -93,7 +93,7 @@ List<ParticipantActionSpec> buildParticipantActionSpecs({
     ParticipantActionSpec(
       icon: micPermGranted ? Icons.mic_off : Icons.mic,
       label:
-          micPermGranted ? 'Revoke Mic Permission' : 'Allow Mic Permission',
+          micPermGranted ? 'Revoke mic permission' : 'Allow mic permission',
       visible: isRemote &&
           viewModel.isAudioModeEnable &&
           !isTargetHost &&
@@ -107,7 +107,7 @@ List<ParticipantActionSpec> buildParticipantActionSpecs({
     ),
     ParticipantActionSpec(
       icon: micOn ? Icons.mic_off : Icons.mic,
-      label: micOn ? 'Mute Mic' : 'Ask To Unmute Mic',
+      label: micOn ? 'Mute mic' : 'Ask to unmute mic',
       visible: isRemote &&
           (amIHost || amICoHost) &&
           (!viewModel.isAudioModeEnable || micOn),
@@ -125,8 +125,8 @@ List<ParticipantActionSpec> buildParticipantActionSpecs({
     ParticipantActionSpec(
       icon: videoPermGranted ? Icons.videocam_off : Icons.videocam,
       label: videoPermGranted
-          ? 'Revoke Video Permission'
-          : 'Allow Video Permission',
+          ? 'Revoke video permission'
+          : 'Allow video permission',
       visible: isRemote &&
           viewModel.isVideoModeEnable &&
           !isTargetHost &&
@@ -140,7 +140,7 @@ List<ParticipantActionSpec> buildParticipantActionSpecs({
     ),
     ParticipantActionSpec(
       icon: cameraOn ? Icons.videocam_off : Icons.videocam,
-      label: cameraOn ? 'Turn Off Camera' : 'Ask To Turn ON Camera',
+      label: cameraOn ? 'Turn off camera' : 'Ask to turn on camera',
       visible: isRemote &&
           (amIHost || amICoHost) &&
           (!viewModel.isVideoModeEnable || cameraOn),
@@ -159,8 +159,8 @@ List<ParticipantActionSpec> buildParticipantActionSpecs({
     ParticipantActionSpec(
       icon: annotationPermGranted ? Icons.draw : Icons.draw_outlined,
       label: annotationPermGranted
-          ? 'Revoke Annotation Permission'
-          : 'Allow to Annotate',
+          ? 'Revoke annotation permission'
+          : 'Allow to annotate',
       visible: isRemote &&
           viewModel.isAnnotationEnabled &&
           !isTargetHost &&
@@ -190,7 +190,7 @@ List<ParticipantActionSpec> buildParticipantActionSpecs({
     ParticipantActionSpec(
       icon:
           isTargetCoHost ? Icons.remove_moderator : Icons.admin_panel_settings,
-      label: isTargetCoHost ? 'Remove Co-Host' : 'Make Co-Host',
+      label: isTargetCoHost ? 'Remove co-host' : 'Make co-host',
       visible: isRemote && canToggleCoHost(),
       onTap: () {
         onDismiss();
@@ -199,7 +199,7 @@ List<ParticipantActionSpec> buildParticipantActionSpecs({
     ),
     ParticipantActionSpec(
       icon: Icons.front_hand_outlined,
-      label: 'Lower Hand',
+      label: 'Lower hand',
       visible: isRemote &&
           isHandRaised &&
           (amIHost || amICoHost) &&
@@ -222,7 +222,7 @@ List<ParticipantActionSpec> buildParticipantActionSpecs({
     ),
     ParticipantActionSpec(
       icon: Icons.person_remove,
-      label: 'Remove From Call',
+      label: 'Remove from call',
       visible: isRemote && (amIHost || (amICoHost && !isTargetHost)),
       onTap: () {
         onDismiss();


### PR DESCRIPTION
## Summary

This PR centralizes participant action configuration to provide consistent behavior and UI across participant action surfaces.

## Changes

- Introduced `ParticipantActionSpec` and `buildParticipantActionSpecs` to centralize participant action definitions.
- Refactored `ParticipantQuickActions` and `ParticipantDialogControls` to use the shared action specification.
- Moved rename and annotation unavailable dialog implementations into the shared utility.
- Standardized action ordering, visibility, permission checks, and labeling across mobile and web interfaces.
- Simplified UI state management by delegating action configuration to the shared specification layer.
- Updated participant action labels to use consistent sentence case.
- Added a **"You"** badge for the local participant in `ParticipantQuickActions` to improve user clarity.