### PR TITLE
Feat/advance password improvement

### DIFF
--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -73,6 +73,11 @@ abstract class RestClient {
     @Body() Map<String, dynamic> body,
   );
 
+  @POST("rtc/meeting/update/participantJoinedStatus")
+  Future<BaseResponse> updateParticipantJoinedStatus(
+    @Body() Map<String, dynamic> body,
+  );
+
   @GET("rtc/meeting/participant/meetingStatus")
   Future<BaseResponse<MeetingStatusData>> getMeetingStatus(
     @Header("Authorization") String token,

--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -75,6 +75,7 @@ abstract class RestClient {
 
   @POST("rtc/meeting/update/participantEmail")
   Future<BaseResponse> updateParticipantEmail(
+    @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 

--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -73,6 +73,11 @@ abstract class RestClient {
     @Body() Map<String, dynamic> body,
   );
 
+  @POST("rtc/meeting/update/participantEmail")
+  Future<BaseResponse> updateParticipantEmail(
+    @Body() Map<String, dynamic> body,
+  );
+
   @POST("rtc/meeting/update/participantJoinedStatus")
   Future<BaseResponse> updateParticipantJoinedStatus(
     @Body() Map<String, dynamic> body,

--- a/lib/api/api_client.g.dart
+++ b/lib/api/api_client.g.dart
@@ -249,6 +249,39 @@ class _RestClient implements RestClient {
   }
 
   @override
+  Future<BaseResponse<dynamic>> updateParticipantJoinedStatus(
+    Map<String, dynamic> body,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
+    final _options = _setStreamType<BaseResponse<dynamic>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            'rtc/meeting/update/participantJoinedStatus',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseResponse<dynamic> _value;
+    try {
+      _value = BaseResponse<dynamic>.fromJson(
+        _result.data!,
+        (json) => json as dynamic,
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
   Future<BaseResponse<MeetingStatusData>> getMeetingStatus(
     String token,
     String meetingUid,
@@ -341,6 +374,42 @@ class _RestClient implements RestClient {
       _value = BaseResponse<MeetingDetailsModel>.fromJson(
         _result.data!,
         (json) => MeetingDetailsModel.fromJson(json as Map<String, dynamic>),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<BaseResponse<ObservabilityPayloadModel>> getObservabilityCredentials(
+    String secret,
+    Map<String, dynamic> body,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'secret': secret};
+    _headers.removeWhere((k, v) => v == null);
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
+    final _options = _setStreamType<BaseResponse<ObservabilityPayloadModel>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            'saas/sdk/observability/credentials',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseResponse<ObservabilityPayloadModel> _value;
+    try {
+      _value = BaseResponse<ObservabilityPayloadModel>.fromJson(
+        _result.data!,
+        (json) =>
+            ObservabilityPayloadModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options, response: _result);
@@ -1737,42 +1806,6 @@ class _RestClient implements RestClient {
       _value = BaseResponse<dynamic>.fromJson(
         _result.data!,
         (json) => json as dynamic,
-      );
-    } on Object catch (e, s) {
-      errorLogger?.logError(e, s, _options, response: _result);
-      rethrow;
-    }
-    return _value;
-  }
-
-  @override
-  Future<BaseResponse<ObservabilityPayloadModel>> getObservabilityCredentials(
-    String secret,
-    Map<String, dynamic> body,
-  ) async {
-    final _extra = <String, dynamic>{};
-    final queryParameters = <String, dynamic>{};
-    final _headers = <String, dynamic>{r'secret': secret};
-    _headers.removeWhere((k, v) => v == null);
-    final _data = <String, dynamic>{};
-    _data.addAll(body);
-    final _options = _setStreamType<BaseResponse<ObservabilityPayloadModel>>(
-      Options(method: 'POST', headers: _headers, extra: _extra)
-          .compose(
-            _dio.options,
-            'saas/sdk/observability/credentials',
-            queryParameters: queryParameters,
-            data: _data,
-          )
-          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
-    );
-    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
-    late BaseResponse<ObservabilityPayloadModel> _value;
-    try {
-      _value = BaseResponse<ObservabilityPayloadModel>.fromJson(
-        _result.data!,
-        (json) =>
-            ObservabilityPayloadModel.fromJson(json as Map<String, dynamic>),
       );
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options, response: _result);

--- a/lib/api/api_client.g.dart
+++ b/lib/api/api_client.g.dart
@@ -250,11 +250,13 @@ class _RestClient implements RestClient {
 
   @override
   Future<BaseResponse<dynamic>> updateParticipantEmail(
+    String selfIdentity,
     Map<String, dynamic> body,
   ) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
-    final _headers = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'x-self-identity': selfIdentity};
+    _headers.removeWhere((k, v) => v == null);
     final _data = <String, dynamic>{};
     _data.addAll(body);
     final _options = _setStreamType<BaseResponse<dynamic>>(

--- a/lib/api/api_client.g.dart
+++ b/lib/api/api_client.g.dart
@@ -249,6 +249,39 @@ class _RestClient implements RestClient {
   }
 
   @override
+  Future<BaseResponse<dynamic>> updateParticipantEmail(
+    Map<String, dynamic> body,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
+    final _options = _setStreamType<BaseResponse<dynamic>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            'rtc/meeting/update/participantEmail',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseResponse<dynamic> _value;
+    try {
+      _value = BaseResponse<dynamic>.fromJson(
+        _result.data!,
+        (json) => json as dynamic,
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
   Future<BaseResponse<dynamic>> updateParticipantJoinedStatus(
     Map<String, dynamic> body,
   ) async {

--- a/lib/api/injection.dart
+++ b/lib/api/injection.dart
@@ -1,5 +1,7 @@
 import 'package:daakia_vc_flutter_sdk/utils/constants.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 
 import '../model/base_list_response.dart';
 import '../model/base_response.dart';
@@ -14,6 +16,28 @@ RestClient get apiClient => _apiClientInstance ??= RestClient(setDio());
 Dio setDio() {
   final dio = Dio();
   dio.options.baseUrl = Constant.baseUrl;
+
+  dio.interceptors.add(
+    PrettyDioLogger(
+      requestHeader: true,
+      requestBody: true,
+      responseBody: true,
+      responseHeader: false,
+      error: true,
+      compact: true,
+      maxWidth: 90,
+      enabled: kDebugMode,
+      filter: (options, args) {
+        // Don't print requests with URIs containing '/posts'
+        if (options.path.contains('/posts')) {
+          return false;
+        }
+
+        // Don't print responses with Uint8List data
+        return !args.isResponse || !args.hasUint8ListData;
+      },
+    ),
+  );
 
   dio.interceptors.add(
     InterceptorsWrapper(

--- a/lib/model/event_password_protected_data.dart
+++ b/lib/model/event_password_protected_data.dart
@@ -1,15 +1,18 @@
 class EventPasswordProtectedData{
   bool? passwordVerified;
+  String? participantEmail;
 
-  EventPasswordProtectedData({this.passwordVerified});
+  EventPasswordProtectedData({this.passwordVerified, this.participantEmail});
 
   EventPasswordProtectedData.fromJson(Map<String, dynamic> json) {
     passwordVerified = json['password_verified'];
+    participantEmail = json['participant_email'];
   }
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = <String, dynamic>{};
     data['password_verified'] = passwordVerified;
+    data['participant_email'] = participantEmail;
     return data;
   }
 }

--- a/lib/model/meeting_details.dart
+++ b/lib/model/meeting_details.dart
@@ -7,11 +7,13 @@ class MeetingDetails {
   String authorizationToken;
   String livekitToken;
   MeetingDetailsModel? meetingBasicDetails;
+  final String? participantEmail;
 
   MeetingDetails(
       {required this.meetingUid,
       this.features,
       required this.authorizationToken,
         required this.livekitToken,
-      required this.meetingBasicDetails});
+      required this.meetingBasicDetails,
+      this.participantEmail});
 }

--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -55,8 +55,8 @@ class _PreJoinState extends State<PreJoinScreen> {
   late MeetingDetails meetingDetails;
 
   var name = "";
-  var email = "";
   var password = "";
+  String? _participantEmail;
 
   var _obscurePassword = true;
 
@@ -231,7 +231,7 @@ class _PreJoinState extends State<PreJoinScreen> {
     }
     if (!widget.isHost &&
         widget.basicMeetingDetails?.isStandardPassword == true) {
-      return "This meeting requires email/password verification. Disable skipPreJoinPage for this meeting type.";
+      return "This meeting requires password verification. Disable skipPreJoinPage for this meeting type.";
     }
     if (!widget.isHost &&
         widget.basicMeetingDetails?.isCommonPassword == true) {
@@ -772,7 +772,8 @@ class _PreJoinState extends State<PreJoinScreen> {
           authorizationToken: hostToken,
           livekitToken: livekitToken,
           features: features,
-          meetingBasicDetails: widget.basicMeetingDetails);
+          meetingBasicDetails: widget.basicMeetingDetails,
+          participantEmail: _participantEmail);
       if (mounted) {
         final navigator = Navigator.of(this.context);
         await navigator.push<void>(
@@ -968,33 +969,6 @@ class _PreJoinState extends State<PreJoinScreen> {
                         LengthLimitingTextInputFormatter(50),
                       ],
                       onChanged: (value) => setState(() => name = value),
-                    ),
-                  ),
-                  Visibility(
-                    visible: !widget.isHost &&
-                        !_shouldBypassParticipantChecks &&
-                        (widget.basicMeetingDetails?.isStandardPassword ==
-                            true),
-                    child: Container(
-                      margin: const EdgeInsets.symmetric(
-                          horizontal: 20, vertical: 10),
-                      // Equivalent to marginHorizontal="20dp" and marginTop="10dp"
-                      child: TextFormField(
-                        decoration: const InputDecoration(
-                          labelText: 'Email*', // Equivalent to hint="Name*"
-                          border: OutlineInputBorder(),
-                        ),
-                        style: const TextStyle(
-                          color: Colors
-                              .black, // Equivalent to textColor="@color/black"
-                        ),
-                        enabled: true, // Equivalent to android:enabled="false"
-                        onChanged: (String? value) {
-                          setState(() {
-                            email = value ?? "";
-                          });
-                        },
-                      ),
                     ),
                   ),
                   Visibility(
@@ -1465,25 +1439,11 @@ class _PreJoinState extends State<PreJoinScreen> {
   }
 
   bool checkValidity() {
-    var isValid = false;
-    if (email.isNotEmpty) {
-      if (Utils.isValidEmail(email)) {
-        isValid = true;
-      } else {
-        Utils.showSnackBar(context, message: "Invalid email");
-        return false;
-      }
-    } else {
-      Utils.showSnackBar(context, message: "Please enter your email");
-      return false;
-    }
     if (password.isEmpty) {
       Utils.showSnackBar(context, message: "Please enter your password");
       return false;
-    } else {
-      isValid = true;
     }
-    return isValid;
+    return true;
   }
 
   void verifyCommonPasswordProtectedMeeting(Function stopLoading) {
@@ -1511,12 +1471,12 @@ class _PreJoinState extends State<PreJoinScreen> {
   void verifyPasswordProtectedMeeting(Function stopLoading) {
     networkRequestHandlerWithMessage(
       apiCall: () => apiClient.verifyMeetingPassword({
-        "email": email,
         "password": password,
         "meeting_uid": widget.meetingId
       }),
       onSuccess: (response) {
         if (response?.data?.passwordVerified == true) {
+          _participantEmail = response?.data?.participantEmail;
           passwordVerified(stopLoading);
         } else {
           passwordNotVerified(stopLoading,

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -192,6 +192,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
 
       viewModel?.registerCaption();
       viewModel?.storeMeetingDetails();
+      viewModel?.notifyParticipantJoinedStatus();
       viewModel?.requestChatHistory();
       viewModel?.requestRaiseHand();
 

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2983,6 +2983,20 @@ class RtcViewmodel extends ChangeNotifier {
         isCoHost ? AttendanceRole.cohost : AttendanceRole.participant);
   }
 
+  // Only fires for the advance-password flow, where verify/password returns
+  // the participant's email; other join flows have no email to report.
+  void notifyParticipantJoinedStatus() {
+    final participantEmail = meetingDetails.participantEmail;
+    if (participantEmail == null || participantEmail.isEmpty) return;
+    Map<String, dynamic> body = {
+      "meeting_uid": meetingDetails.meetingUid,
+      "participant_email": participantEmail,
+      "is_joined": true,
+    };
+    networkRequestHandler(
+        apiCall: () => apiClient.updateParticipantJoinedStatus(body));
+  }
+
   void requestChatHistory() {
     if (room.remoteParticipants.values.isEmpty) return;
     final participant = room.remoteParticipants.values.first;

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2988,14 +2988,13 @@ class RtcViewmodel extends ChangeNotifier {
   void notifyParticipantJoinedStatus() {
     final participantEmail = meetingDetails.participantEmail;
     if (participantEmail == null || participantEmail.isEmpty) return;
-    final participantIdentity = room.localParticipant?.identity;
     Map<String, dynamic> emailBody = {
       "meeting_uid": meetingDetails.meetingUid,
-      "participant_identity": participantIdentity,
+      "participant_identity": selfIdentity,
       "participant_email": participantEmail,
     };
     networkRequestHandler(
-        apiCall: () => apiClient.updateParticipantEmail(emailBody),
+        apiCall: () => apiClient.updateParticipantEmail(selfIdentity, emailBody),
         onSuccess: (_) {
           Map<String, dynamic> body = {
             "meeting_uid": meetingDetails.meetingUid,

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -2988,13 +2988,23 @@ class RtcViewmodel extends ChangeNotifier {
   void notifyParticipantJoinedStatus() {
     final participantEmail = meetingDetails.participantEmail;
     if (participantEmail == null || participantEmail.isEmpty) return;
-    Map<String, dynamic> body = {
+    final participantIdentity = room.localParticipant?.identity;
+    Map<String, dynamic> emailBody = {
       "meeting_uid": meetingDetails.meetingUid,
+      "participant_identity": participantIdentity,
       "participant_email": participantEmail,
-      "is_joined": true,
     };
     networkRequestHandler(
-        apiCall: () => apiClient.updateParticipantJoinedStatus(body));
+        apiCall: () => apiClient.updateParticipantEmail(emailBody),
+        onSuccess: (_) {
+          Map<String, dynamic> body = {
+            "meeting_uid": meetingDetails.meetingUid,
+            "participant_email": participantEmail,
+            "is_joined": true,
+          };
+          networkRequestHandler(
+              apiCall: () => apiClient.updateParticipantJoinedStatus(body));
+        });
   }
 
   void requestChatHistory() {


### PR DESCRIPTION
## Summary

This PR improves participant join tracking for password-protected meetings and enhances backend synchronization during the meeting join flow.

## Changes

- Added `updateParticipantJoinedStatus` API to track successful participant joins.
- Added `updateParticipantEmail` API to synchronize participant email before join status updates.
- Simplified password-protected meeting flow by removing manual email input and using the email returned from password verification.
- Updated `MeetingDetails` and `EventPasswordProtectedData` to propagate `participantEmail`.
- Added `notifyParticipantJoinedStatus` in `RtcViewModel` to update participant email and notify the backend after a successful room connection.
- Added `x-self-identity` header support for participant email updates.
- Ensured participant identity is derived from `selfIdentity` during email synchronization.
- Integrated `PrettyDioLogger` for improved request/response logging in debug builds.