### PR TITLE
Feat/participant invite list

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -651,10 +651,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1112,10 +1112,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -23,6 +23,7 @@ import '../model/meeting_status_model.dart';
 import '../model/event_password_protected_data.dart';
 import '../model/host_controls_data.dart';
 import '../model/host_token_model.dart';
+import '../model/invited_participant.dart';
 import '../model/meeting_details_model.dart';
 import '../model/recording_dispatch_data.dart';
 import '../model/remote_participant_consent_model.dart';
@@ -360,5 +361,19 @@ abstract class RestClient {
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
+  );
+
+  //-------------------[INVITED PARTICIPANTS]-------------------
+
+  @POST("rtc/meeting/invite/participants")
+  Future<BaseResponse> inviteParticipants(
+    @Header("x-self-identity") String selfIdentity,
+    @Body() Map<String, dynamic> body,
+  );
+
+  @GET("rtc/meeting/invited/participants")
+  Future<BaseResponse<InvitedParticipantsData>> getInvitedParticipants(
+    @Header("x-self-identity") String selfIdentity,
+    @Query("meeting_uid") String meetingUid,
   );
 }

--- a/lib/api/api_client.g.dart
+++ b/lib/api/api_client.g.dart
@@ -1849,6 +1849,76 @@ class _RestClient implements RestClient {
     return _value;
   }
 
+  @override
+  Future<BaseResponse<dynamic>> inviteParticipants(
+    String selfIdentity,
+    Map<String, dynamic> body,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{r'x-self-identity': selfIdentity};
+    _headers.removeWhere((k, v) => v == null);
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
+    final _options = _setStreamType<BaseResponse<dynamic>>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            'rtc/meeting/invite/participants',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseResponse<dynamic> _value;
+    try {
+      _value = BaseResponse<dynamic>.fromJson(
+        _result.data!,
+        (json) => json as dynamic,
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<BaseResponse<InvitedParticipantsData>> getInvitedParticipants(
+    String selfIdentity,
+    String meetingUid,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'meeting_uid': meetingUid};
+    final _headers = <String, dynamic>{r'x-self-identity': selfIdentity};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<BaseResponse<InvitedParticipantsData>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            'rtc/meeting/invited/participants',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late BaseResponse<InvitedParticipantsData> _value;
+    try {
+      _value = BaseResponse<InvitedParticipantsData>.fromJson(
+        _result.data!,
+        (json) =>
+            InvitedParticipantsData.fromJson(json as Map<String, dynamic>),
+      );
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/model/invited_participant.dart
+++ b/lib/model/invited_participant.dart
@@ -1,0 +1,51 @@
+class InvitedParticipant {
+  int? id;
+  String? attendee;
+  String? participantStatus;
+  String? participantIdentity;
+
+  InvitedParticipant(
+      {this.id,
+      this.attendee,
+      this.participantStatus,
+      this.participantIdentity});
+
+  InvitedParticipant.fromJson(Map<String, dynamic> json) {
+    id = json['id'];
+    attendee = json['attendee'];
+    participantStatus = json['participant_status'];
+    participantIdentity = json['participant_identity'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['id'] = id;
+    data['attendee'] = attendee;
+    data['participant_status'] = participantStatus;
+    data['participant_identity'] = participantIdentity;
+    return data;
+  }
+}
+
+class InvitedParticipantsData {
+  List<InvitedParticipant>? invitedParticipants;
+
+  InvitedParticipantsData({this.invitedParticipants});
+
+  InvitedParticipantsData.fromJson(Map<String, dynamic> json) {
+    if (json['invited_participants'] != null) {
+      invitedParticipants = (json['invited_participants'] as List)
+          .map((item) => InvitedParticipant.fromJson(item))
+          .toList();
+    }
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    if (invitedParticipants != null) {
+      data['invited_participants'] =
+          invitedParticipants!.map((item) => item.toJson()).toList();
+    }
+    return data;
+  }
+}

--- a/lib/presentation/pages/all_participant_page.dart
+++ b/lib/presentation/pages/all_participant_page.dart
@@ -1,3 +1,4 @@
+import 'package:daakia_vc_flutter_sdk/presentation/widgets/invited_participant_widget.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/widgets/joined_participant_widget.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/widgets/lobby_request_widget.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/widgets/pending_attendance_widget.dart';
@@ -31,6 +32,9 @@ class AllParticipantPage extends StatelessWidget {
                 LobbyRequestWidget(viewModel: viewModel),
                 RaisedHandParticipantWidget(viewModel: viewModel),
                 JoinedParticipantWidget(viewModel: viewModel),
+                if (viewModel.invitedParticipantList.isNotEmpty &&
+                    (viewModel.isHost() || viewModel.isCoHost()))
+                  InvitedParticipantWidget(viewModel: viewModel),
                 if (viewModel.pendingParticipantList.isNotEmpty &&
                     (viewModel.isHost() || viewModel.isCoHost()))
                   PendingAttendanceWidget(viewModel: viewModel)

--- a/lib/presentation/widgets/invited_participant_widget.dart
+++ b/lib/presentation/widgets/invited_participant_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../resources/colors/color.dart';
 import '../../utils/utils.dart';
 import '../../viewmodel/rtc_viewmodel.dart';
 import 'initials_circle.dart';
@@ -66,10 +67,27 @@ class _InvitedParticipantWidgetState extends State<InvitedParticipantWidget> {
             ),
             Row(
               children: [
-                TextButton(
+                ElevatedButton(
                   onPressed: canRemindAll
                       ? () => _remindAll(remainingAttendees)
                       : null,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: themeColor,
+                    foregroundColor: Colors.white,
+                    disabledBackgroundColor: themeColor.withValues(alpha: 0.4),
+                    disabledForegroundColor: Colors.white70,
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    minimumSize: Size.zero,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    textStyle: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
                   child: _isRemindAllLoading
                       ? const SizedBox(
                           width: 14,

--- a/lib/presentation/widgets/invited_participant_widget.dart
+++ b/lib/presentation/widgets/invited_participant_widget.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+import '../../viewmodel/rtc_viewmodel.dart';
+
+class InvitedParticipantWidget extends StatefulWidget {
+  const InvitedParticipantWidget({required this.viewModel, super.key});
+
+  final RtcViewmodel viewModel;
+
+  @override
+  State<InvitedParticipantWidget> createState() =>
+      _InvitedParticipantWidgetState();
+}
+
+class _InvitedParticipantWidgetState extends State<InvitedParticipantWidget> {
+  bool isExpanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final invitedList = widget.viewModel.invitedParticipantList;
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Participants Not Joined (${invitedList.length})',
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            Row(
+              children: [
+                TextButton(
+                  onPressed: widget.viewModel.remindAllParticipants,
+                  child: const Text('Remind All'),
+                ),
+                IconButton(
+                  onPressed: () {
+                    setState(() {
+                      isExpanded = !isExpanded;
+                    });
+                  },
+                  icon: Icon(
+                    isExpanded
+                        ? Icons.arrow_drop_down_sharp
+                        : Icons.arrow_right_sharp,
+                    color: Colors.white,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+        if (isExpanded)
+          ListView.builder(
+            shrinkWrap: true,
+            padding: EdgeInsets.zero,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: invitedList.length,
+            itemBuilder: (context, index) {
+              final invitee = invitedList[index];
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 2.0),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        invitee.attendee ?? "Unknown",
+                        style: const TextStyle(color: Colors.white),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    IconButton(
+                      tooltip: 'Remind',
+                      onPressed: invitee.attendee == null
+                          ? null
+                          : () => widget.viewModel
+                              .remindParticipant(invitee.attendee!),
+                      icon: const Icon(Icons.notifications_active_outlined,
+                          color: Colors.white),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/invited_participant_widget.dart
+++ b/lib/presentation/widgets/invited_participant_widget.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
+import '../../utils/utils.dart';
 import '../../viewmodel/rtc_viewmodel.dart';
+import 'initials_circle.dart';
 
 class InvitedParticipantWidget extends StatefulWidget {
   const InvitedParticipantWidget({required this.viewModel, super.key});
@@ -14,10 +16,42 @@ class InvitedParticipantWidget extends StatefulWidget {
 
 class _InvitedParticipantWidgetState extends State<InvitedParticipantWidget> {
   bool isExpanded = false;
+  bool _isRemindAllLoading = false;
+  final Set<String> _remindedAttendees = {};
+  final Set<String> _remindingAttendees = {};
+
+  Future<void> _remindOne(String attendee) async {
+    setState(() => _remindingAttendees.add(attendee));
+    final success = await widget.viewModel.remindParticipant(attendee);
+    if (!mounted) return;
+    setState(() {
+      _remindingAttendees.remove(attendee);
+      if (success) _remindedAttendees.add(attendee);
+    });
+  }
+
+  Future<void> _remindAll(List<String> remainingAttendees) async {
+    setState(() => _isRemindAllLoading = true);
+    final success =
+        await widget.viewModel.remindAllParticipants(emails: remainingAttendees);
+    if (!mounted) return;
+    setState(() {
+      _isRemindAllLoading = false;
+      if (success) {
+        _remindedAttendees.addAll(remainingAttendees);
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     final invitedList = widget.viewModel.invitedParticipantList;
+    final remainingAttendees = invitedList
+        .map((invitee) => invitee.attendee)
+        .whereType<String>()
+        .where((attendee) => !_remindedAttendees.contains(attendee))
+        .toList();
+    final canRemindAll = !_isRemindAllLoading && remainingAttendees.isNotEmpty;
     return Column(
       children: [
         Row(
@@ -33,8 +67,17 @@ class _InvitedParticipantWidgetState extends State<InvitedParticipantWidget> {
             Row(
               children: [
                 TextButton(
-                  onPressed: widget.viewModel.remindAllParticipants,
-                  child: const Text('Remind All'),
+                  onPressed: canRemindAll
+                      ? () => _remindAll(remainingAttendees)
+                      : null,
+                  child: _isRemindAllLoading
+                      ? const SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(
+                              strokeWidth: 2, color: Colors.white),
+                        )
+                      : const Text('Remind All'),
                 ),
                 IconButton(
                   onPressed: () {
@@ -61,26 +104,43 @@ class _InvitedParticipantWidgetState extends State<InvitedParticipantWidget> {
             itemCount: invitedList.length,
             itemBuilder: (context, index) {
               final invitee = invitedList[index];
+              final attendee = invitee.attendee;
+              final isLoading =
+                  attendee != null && _remindingAttendees.contains(attendee);
+              final isReminded =
+                  attendee != null && _remindedAttendees.contains(attendee);
               return Padding(
-                padding: const EdgeInsets.symmetric(vertical: 2.0),
+                padding: const EdgeInsets.symmetric(vertical: 4.0),
                 child: Row(
                   children: [
+                    InitialsCircle(initials: Utils.getInitials(attendee)),
+                    const SizedBox(width: 10),
                     Expanded(
                       child: Text(
-                        invitee.attendee ?? "Unknown",
+                        attendee ?? "Unknown",
                         style: const TextStyle(color: Colors.white),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                       ),
                     ),
                     IconButton(
-                      tooltip: 'Remind',
-                      onPressed: invitee.attendee == null
+                      tooltip: isReminded ? 'Reminded' : 'Remind',
+                      onPressed: (attendee == null || isLoading || isReminded)
                           ? null
-                          : () => widget.viewModel
-                              .remindParticipant(invitee.attendee!),
-                      icon: const Icon(Icons.notifications_active_outlined,
-                          color: Colors.white),
+                          : () => _remindOne(attendee),
+                      icon: isLoading
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(
+                                  strokeWidth: 2, color: Colors.white),
+                            )
+                          : Icon(
+                              isReminded
+                                  ? Icons.notifications_active
+                                  : Icons.notifications_active_outlined,
+                              color: isReminded ? Colors.white38 : Colors.white,
+                            ),
                     ),
                   ],
                 ),

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -170,6 +170,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
       _initializeWebViewController();
       viewModel?.getWhiteboardData();
       viewModel?.getAttendanceListForParticipant();
+      viewModel?.fetchInvitedParticipants(silent: true);
       if (viewModel?.meetingDetails.features?.isRecordingConsentAllowed() ==
           true) {
         viewModel?.checkSessionStatus(
@@ -487,6 +488,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
       var viewModel = _livekitProviderKey.currentState?.viewModel;
       viewModel?.setRecording(widget.room.isRecording);
       viewModel?.getAttendanceListForParticipant();
+      viewModel?.fetchInvitedParticipants(silent: true);
       viewModel?.addParticipantToConsentList(event.participant);
       viewModel?.sendPrivateChatHistory(event.participant.identity);
       _sortParticipants();
@@ -498,6 +500,8 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
           .removeParticipantFromConsentList(event.participant.identity);
       _livekitProviderKey.currentState?.viewModel
           .getAttendanceListForParticipant();
+      _livekitProviderKey.currentState?.viewModel
+          .fetchInvitedParticipants(silent: true);
       _livekitProviderKey.currentState?.viewModel.clearRaiseHandMemory(event.participant.identity);
       _sortParticipants();
     })
@@ -745,6 +749,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         storageHelper.setAttendanceRole(AttendanceRole.cohost);
         storageHelper.setHostToken(remoteData.token ?? "");
         viewModel?.getAttendanceListForParticipant();
+        viewModel?.fetchInvitedParticipants(silent: true);
         showSnackBar(message: "${remoteData.identity?.name} made you a Co-Host");
         break;
 
@@ -977,6 +982,10 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         if (isHidden && viewModel?.isParticipantPageOpen == true) {
           _innerNavigatorKey.currentState?.maybePop();
         }
+        break;
+
+      case MeetingActions.refreshInvitedParticipants:
+        viewModel?.fetchInvitedParticipants(silent: true);
         break;
 
       case "":

--- a/lib/utils/meeting_actions.dart
+++ b/lib/utils/meeting_actions.dart
@@ -110,6 +110,8 @@ class MeetingActions {
 
   static const String revokeAnnotationPermission = "revoke-annotation-permission";
 
+  static const String refreshInvitedParticipants = "refresh_invited_participants";
+
   // ✅ Add new fields here
 
   // ✅ Method to check if an action is valid
@@ -181,6 +183,7 @@ class MeetingActions {
     allowScreenShareAnnotation,
     allowAnnotationPermission,
     revokeAnnotationPermission,
+    refreshInvitedParticipants,
     // ✅ Add new fields here
   };
 }

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -1687,15 +1687,17 @@ class RtcViewmodel extends ChangeNotifier {
     );
   }
 
-  void sendInviteEmails(List<String> emails) {
-    if (emails.isEmpty) return;
+  Future<bool> sendInviteEmails(List<String> emails) async {
+    if (emails.isEmpty) return false;
     Map<String, dynamic> body = {
       "meeting_uid": meetingDetails.meetingUid,
       "participantsEmail": emails,
     };
-    networkRequestHandler(
+    bool isSuccess = false;
+    await networkRequestHandler(
       apiCall: () => apiClient.inviteParticipants(selfIdentity, body),
       onSuccess: (_) {
+        isSuccess = true;
         sendMessageToUI("Invite sent");
         sendAction(ActionModel(action: MeetingActions.refreshInvitedParticipants));
         for (final delayMs in [500, 1500, 3000]) {
@@ -1705,16 +1707,18 @@ class RtcViewmodel extends ChangeNotifier {
       },
       onError: (message) => sendMessageToUI(message),
     );
+    return isSuccess;
   }
 
-  void remindParticipant(String email) => sendInviteEmails([email]);
+  Future<bool> remindParticipant(String email) => sendInviteEmails([email]);
 
-  void remindAllParticipants() {
-    final emails = invitedParticipantList
-        .map((invitee) => invitee.attendee)
-        .whereType<String>()
-        .toList();
-    sendInviteEmails(emails);
+  Future<bool> remindAllParticipants({List<String>? emails}) {
+    final targets = emails ??
+        invitedParticipantList
+            .map((invitee) => invitee.attendee)
+            .whereType<String>()
+            .toList();
+    return sendInviteEmails(targets);
   }
 
   //Recording Consent Flow

--- a/lib/viewmodel/rtc_viewmodel.dart
+++ b/lib/viewmodel/rtc_viewmodel.dart
@@ -8,6 +8,7 @@ import 'package:daakia_vc_flutter_sdk/api/injection.dart';
 import 'package:daakia_vc_flutter_sdk/events/rtc_events.dart';
 import 'package:daakia_vc_flutter_sdk/model/consent_participant.dart';
 import 'package:daakia_vc_flutter_sdk/model/edit_message.dart';
+import 'package:daakia_vc_flutter_sdk/model/invited_participant.dart';
 import 'package:daakia_vc_flutter_sdk/model/participant_attendance_data.dart';
 import 'package:daakia_vc_flutter_sdk/model/reaction_model.dart';
 import 'package:daakia_vc_flutter_sdk/model/remote_activity_data.dart';
@@ -1648,6 +1649,72 @@ class RtcViewmodel extends ChangeNotifier {
       }
     }
     pendingParticipantList = tempList;
+  }
+
+  //Invited Participants (email invite / reminder flow for standard-password meetings)
+
+  bool get isInviteParticipantEnabled =>
+      meetingDetails.meetingBasicDetails?.isStandardPassword == true;
+
+  List<InvitedParticipant> _invitedParticipantList = [];
+
+  List<InvitedParticipant> get invitedParticipantList =>
+      _invitedParticipantList;
+
+  void _applyInvitedParticipants(List<InvitedParticipant> rawList) {
+    final seenAttendees = <String>{};
+    final tempList = <InvitedParticipant>[];
+    for (var invitee in rawList) {
+      final attendee = invitee.attendee;
+      if (attendee == null || attendee.isEmpty) continue;
+      if (invitee.participantStatus?.toLowerCase() == 'joined') continue;
+      if (!seenAttendees.add(attendee)) continue;
+      tempList.add(invitee);
+    }
+    _invitedParticipantList = tempList;
+    notifyListeners();
+  }
+
+  void fetchInvitedParticipants({bool silent = false}) {
+    if (!isHost() && !isCoHost()) return;
+    if (!isInviteParticipantEnabled) return;
+    networkRequestHandler(
+      apiCall: () => apiClient.getInvitedParticipants(
+          selfIdentity, meetingDetails.meetingUid),
+      onSuccess: (data) =>
+          _applyInvitedParticipants(data?.invitedParticipants ?? []),
+      onError: silent ? null : (message) => sendMessageToUI(message),
+    );
+  }
+
+  void sendInviteEmails(List<String> emails) {
+    if (emails.isEmpty) return;
+    Map<String, dynamic> body = {
+      "meeting_uid": meetingDetails.meetingUid,
+      "participantsEmail": emails,
+    };
+    networkRequestHandler(
+      apiCall: () => apiClient.inviteParticipants(selfIdentity, body),
+      onSuccess: (_) {
+        sendMessageToUI("Invite sent");
+        sendAction(ActionModel(action: MeetingActions.refreshInvitedParticipants));
+        for (final delayMs in [500, 1500, 3000]) {
+          Timer(Duration(milliseconds: delayMs),
+              () => fetchInvitedParticipants(silent: true));
+        }
+      },
+      onError: (message) => sendMessageToUI(message),
+    );
+  }
+
+  void remindParticipant(String email) => sendInviteEmails([email]);
+
+  void remindAllParticipants() {
+    final emails = invitedParticipantList
+        .map((invitee) => invitee.attendee)
+        .whereType<String>()
+        .toList();
+    sendInviteEmails(emails);
   }
 
   //Recording Consent Flow

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -772,10 +772,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: "direct main"
     description:
@@ -1337,10 +1337,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

This PR adds invited participant management, reminder functionality, and automatic synchronization of invitation status during meetings.

## Changes

- Added `InvitedParticipant` and `InvitedParticipantsData` models.
- Added `inviteParticipants` and `getInvitedParticipants` API endpoints.
- Implemented invited participant management in `RtcViewModel`, including fetching, filtering, and sending invitation reminders.
- Added `InvitedParticipantWidget` to display participants who have not yet joined.
- Added support for reminding individual participants or all pending participants at once.
- Integrated the invited participants section into `AllParticipantPage` for hosts and co-hosts.
- Automatically refreshed invited participant data on room join, participant join/leave events, and `refresh_invited_participants` meeting actions.
- Added `refreshInvitedParticipants` meeting action constant.
- Improved **Remind All** button visibility based on the current invited participant state.