### PR TITLE
Fix/sdk theme isolation

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/lib/daakia_vc_flutter_sdk.dart
+++ b/lib/daakia_vc_flutter_sdk.dart
@@ -6,7 +6,7 @@ import 'package:daakia_vc_flutter_sdk/api/injection.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/screens/license_expired.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/screens/loading_screen.dart';
 import 'package:daakia_vc_flutter_sdk/presentation/screens/prejoin_screen.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import 'model/daakia_meeting_configuration.dart';
@@ -15,6 +15,7 @@ import 'model/observability_config.dart';
 import 'model/observability_payload_model.dart';
 import 'service/daakia_vc_datadog_service.dart';
 import 'service/daakia_vc_sentry_service.dart';
+import 'theme/daakia_sdk_theme.dart';
 import 'utils/constants.dart';
 import 'utils/sdk_crypto.dart';
 
@@ -232,6 +233,6 @@ class _DaakiaVideoConferenceState extends State<DaakiaVideoConferenceWidget> {
     } else {
       screen = LicenseExpiredScreen(_licenseMessage);
     }
-    return screen;
+    return Theme(data: DaakiaSdkTheme.preMeeting, child: screen);
   }
 }

--- a/lib/rtc/room.dart
+++ b/lib/rtc/room.dart
@@ -20,6 +20,7 @@ import 'package:daakia_vc_flutter_sdk/rtc/widgets/participant_info.dart';
 import 'package:daakia_vc_flutter_sdk/rtc/widgets/pip_screen.dart';
 import 'package:daakia_vc_flutter_sdk/rtc/widgets/rtc_controls.dart';
 import 'package:daakia_vc_flutter_sdk/rtc/widgets/white_board_widget.dart';
+import 'package:daakia_vc_flutter_sdk/theme/daakia_sdk_theme.dart';
 import 'package:daakia_vc_flutter_sdk/utils/constants.dart';
 import 'package:daakia_vc_flutter_sdk/utils/datadog_disconnect_logger.dart';
 import 'package:daakia_vc_flutter_sdk/utils/datadog_reconnect_logger.dart';
@@ -1319,9 +1320,7 @@ class _RoomPageState extends State<RoomPage> with WidgetsBindingObserver {
         child: MaterialApp(
           navigatorKey: _innerNavigatorKey,
           debugShowCheckedModeBanner: false,
-          theme: Theme.of(context).copyWith(
-            scaffoldBackgroundColor: Colors.black,
-          ),
+          theme: DaakiaSdkTheme.meeting,
           home: AnnotatedRegion<SystemUiOverlayStyle>(
             value: const SystemUiOverlayStyle(
               statusBarColor: Colors.transparent,

--- a/lib/theme/daakia_sdk_theme.dart
+++ b/lib/theme/daakia_sdk_theme.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import '../resources/colors/color.dart';
+
+/// Self-contained [ThemeData] the SDK applies to its own widget subtree.
+///
+/// Host apps embed [DaakiaVideoConferenceWidget] inside their own
+/// `MaterialApp`/`Theme`, and Flutter's Material widgets (`TextField`,
+/// `AlertDialog`, `AppBar`, etc.) fall back to that ambient theme for any
+/// property the SDK doesn't hardcode. Since most SDK screens only hardcode
+/// the colors they care about, an unrelated host theme (e.g. a global
+/// `filled: true` `InputDecorationTheme`) can bleed into unstyled widgets —
+/// e.g. the chat message field rendering as a white pill instead of its
+/// intended dark container. Using this isolated theme instead of
+/// `Theme.of(context)` removes that dependency so every screen looks the
+/// same no matter what theme the host app declares.
+///
+/// The SDK doesn't support host-configurable theming yet — this is a fixed
+/// default. When that lands, it becomes the base a theme config can override.
+class DaakiaSdkTheme {
+  DaakiaSdkTheme._();
+
+  /// For screens that render before the in-meeting UI (loading,
+  /// license-expired, pre-join) — these already hardcode a light-card /
+  /// dark-text look, so this just isolates them from the host's theme
+  /// rather than redesigning them.
+  static final ThemeData preMeeting = ThemeData(
+    useMaterial3: true,
+    colorScheme: ColorScheme.fromSeed(seedColor: themeColor),
+  );
+
+  /// For the in-meeting UI (room.dart's inner MaterialApp). Same base as
+  /// [preMeeting] — the SDK's dialogs are consistently designed as light
+  /// Material cards over the meeting's dark backdrop — with the backdrop
+  /// forced black.
+  static final ThemeData meeting = preMeeting.copyWith(
+    scaffoldBackgroundColor: Colors.black,
+  );
+}


### PR DESCRIPTION
## Summary

This PR introduces isolated SDK theming to ensure consistent UI across host applications and updates Android Gradle configuration for Flutter compatibility.

## Changes

- Added `DaakiaSdkTheme` with self-contained SDK theme configurations.
- Added a Material 3-based `preMeeting` theme for loading and pre-join screens.
- Added a `meeting` theme with a black scaffold background for in-meeting screens.
- Prevented host application themes from affecting SDK components such as `TextField` and `AlertDialog`.
- Applied the centralized pre-meeting theme across SDK entry screens.
- Updated `Room` to use the centralized `DaakiaSdkTheme.meeting` configuration.
- Removed manual meeting theme overrides in favor of the shared theme configuration.
- Added Flutter migration flags to `gradle.properties`:
  - `android.builtInKotlin=false`
  - `android.newDsl=false`