### PR TITLE
Doc/v4.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # CHANGELOG
 
+## v4.5.2 – (2026-07)
+
+### 🚀 New Features
+- **Duplicate Identity Handling** — Detects multi-device/duplicate joins and shows a modal dialog with platform-specific guidance instead of a snackbar; skipped for guest users.
+- **SDK Theme Isolation** — Introduced an isolated SDK theme applied consistently across pre-meeting and in-meeting screens, replacing ad-hoc theme usage in `Room`.
+- **Invited Participants & Reminder Flow** — Track invited participants and send join reminders, with a "remind all" action.
+- **Participant Quick Actions** — Tap a participant tile to open a quick-actions bottom sheet, including a "You" badge for the local participant.
+- **Advance Password / Join Status Improvements** — Track participant join status, update participant email before the joining-status notification, and refine password verification.
+- **Screen-Share Paused State UI** — Visual indicator when screen sharing is paused.
+- **Call Terminology Support** — `DaakiaMeetingConfiguration.useCallTerminology` support in `RoomPage`, with documentation.
+- **End Meeting Confirmation** — Added a confirmation dialog to `EndMeetingBottomSheet`.
+
+### 🧩 Improvements
+- Centralized participant action logic into a unified specification.
+- Refactored private chat navigation and initialization/event subscription handling.
+
+### 🐞 Bug Fixes
+- Fixed reconnection UI flicker during network drops.
+- Fixed public chat history request handling.
+- Fixed remind-all button visibility.
+- Normalized iOS platform identifier to lowercase.
+
 ## v4.5.1 – (2026-06)
 
 ### 🚀 New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v4.5.2 – (2026-07)
 
+### ⚠️ Migration
+- **`secretKey` is now optional and deprecated** on `DaakiaVideoConferenceWidget` — set it once via
+  `DaakiaSdk.initialize(secret: ...)` at app startup instead. The old flow still works but will be removed
+  in a future major version. See the [Migration Guide](doc/MigrationGuide.md).
+
 ### 🚀 New Features
 - **Duplicate Identity Handling** — Detects multi-device/duplicate joins and shows a modal dialog with platform-specific guidance instead of a snackbar; skipped for guest users.
 - **SDK Theme Isolation** — Introduced an isolated SDK theme applied consistently across pre-meeting and in-meeting screens, replacing ad-hoc theme usage in `Room`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This SDK provides a simple and efficient way to add video conferencing features 
 ✅ **Android**  | ✅ **iOS**
 
 ## Latest Release
-**v4.5.1** - See [CHANGELOG.md](CHANGELOG.md) for detailed release notes and what's new.
+**v4.5.2** - See [CHANGELOG.md](CHANGELOG.md) for detailed release notes and what's new.
 
 # How to use
 

--- a/README.md
+++ b/README.md
@@ -185,12 +185,14 @@ cd ios && pod install
 ```dart
 import 'package:daakia_vc_flutter_sdk/daakia_vc_flutter_sdk.dart';
 
+// main.dart, once at app startup, before runApp()
+DaakiaSdk.initialize(secret: '<YOUR_SECRET_KEY>');
+
 await Navigator.push<void>(
                 context,
                 MaterialPageRoute(
                   builder: (_) => DaakiaVideoConferenceWidget(
                     meetingId: meetingUID,
-                    secretKey: licenseKey,
                     isHost: isHost,
                     configuration: DaakiaMeetingConfiguration (optional),
                   ),
@@ -200,6 +202,10 @@ await Navigator.push<void>(
 
 Use ``DaakiaVideoConferenceWidget`` to start the meeting.
 
+> **Migrating from an older version?** Passing `secretKey` directly to `DaakiaVideoConferenceWidget` is
+> deprecated as of v4.5.2 in favor of `DaakiaSdk.initialize(secret: ...)`. See the
+> [Migration Guide](doc/MigrationGuide.md) for details.
+
 
 ## Parameters
 
@@ -208,8 +214,10 @@ To run the `DaakiaVideoConferenceWidget`, you will need to pass the following pa
 - **`meetingId`** (`String`):  
   This parameter is required to join a specific meeting. It helps identify the unique meeting to which the user will connect.
 
-- **`secretKey`** (`String`):  
-  This is a license key that grants access to the meeting service. It is necessary for secure access.
+- **`secretKey`** (`String`, optional, **deprecated**):  
+  This is a license key that grants access to the meeting service. **Deprecated since v4.5.2** — set it
+  once via `DaakiaSdk.initialize(secret: ...)` at app startup instead of passing it to every widget
+  instance. See the [Migration Guide](doc/MigrationGuide.md).
 
 - **`isHost`** (`bool`, optional):  
   This optional parameter defines the user's role. When set to `true`, the user will join as the host of the meeting; otherwise, they will be a participant.

--- a/doc/MigrationGuide.md
+++ b/doc/MigrationGuide.md
@@ -1,0 +1,52 @@
+# Migration Guide
+
+## Moving `secretKey` to `DaakiaSdk.initialize` (since v4.5.2)
+
+Starting in **v4.5.2**, `DaakiaVideoConferenceWidget.secretKey` is optional and **deprecated**. The
+recommended flow is to set the secret key once at app startup via `DaakiaSdk.initialize`, instead of
+passing it to every `DaakiaVideoConferenceWidget` instance.
+
+> **Note:** The old flow still works. `secretKey` will continue to be honored as a fallback, but it will
+> be removed in a future major version — migrate when convenient.
+
+### Before
+
+```dart
+DaakiaVideoConferenceWidget(
+  meetingId: meetingUID,
+  secretKey: licenseKey,
+  isHost: isHost,
+)
+```
+
+### After
+
+```dart
+// main.dart, once at app startup, before runApp()
+DaakiaSdk.initialize(
+  secret: '<YOUR_SECRET_KEY>',
+  baseUrl: '<BASE_URL>',         // optional, defaults to production
+  whiteboardDomain: '<WB_URL>',  // optional
+);
+
+// meeting screen — no need to pass secretKey anymore
+DaakiaVideoConferenceWidget(
+  meetingId: meetingUID,
+  isHost: isHost,
+)
+```
+
+### Why migrate
+
+- Avoids repeating the secret key on every widget instantiation.
+- If neither `secretKey` nor `DaakiaSdk.initialize(secret: ...)` is set, the widget now shows a clear
+  license error instead of failing silently.
+
+### Steps
+
+1. Call `DaakiaSdk.initialize(secret: '<YOUR_SECRET_KEY>')` once in `main()`, before `runApp()`.
+2. Remove the `secretKey` argument from every `DaakiaVideoConferenceWidget(...)` call site.
+3. If you use `baseUrl` or `whiteboardDomain`, pass them to the same `DaakiaSdk.initialize` call instead of
+   configuring them separately.
+
+No other parameters or behavior change as part of this migration.

--- a/doc/MigrationGuide.md
+++ b/doc/MigrationGuide.md
@@ -23,11 +23,7 @@ DaakiaVideoConferenceWidget(
 
 ```dart
 // main.dart, once at app startup, before runApp()
-DaakiaSdk.initialize(
-  secret: '<YOUR_SECRET_KEY>',
-  baseUrl: '<BASE_URL>',         // optional, defaults to production
-  whiteboardDomain: '<WB_URL>',  // optional
-);
+DaakiaSdk.initialize(secret: '<YOUR_SECRET_KEY>');
 
 // meeting screen — no need to pass secretKey anymore
 DaakiaVideoConferenceWidget(
@@ -46,7 +42,5 @@ DaakiaVideoConferenceWidget(
 
 1. Call `DaakiaSdk.initialize(secret: '<YOUR_SECRET_KEY>')` once in `main()`, before `runApp()`.
 2. Remove the `secretKey` argument from every `DaakiaVideoConferenceWidget(...)` call site.
-3. If you use `baseUrl` or `whiteboardDomain`, pass them to the same `DaakiaSdk.initialize` call instead of
-   configuring them separately.
 
 No other parameters or behavior change as part of this migration.


### PR DESCRIPTION
## Summary

This PR prepares the v4.5.2 release with updated documentation, release notes, and migration guidance for the new SDK initialization flow.

## Changes

- Updated the latest SDK version to `v4.5.2` in `README.md`.
- Added comprehensive v4.5.2 release notes to `CHANGELOG.md`.
- Documented major features, including:
  - Duplicate identity and multi-device session handling.
  - Isolated SDK theming.
  - Invited participant management and reminder flow.
- Documented UI improvements for participant quick actions, paused screen-share states, and end meeting confirmation dialogs.
- Added architectural improvements for centralized participant actions and private chat navigation.
- Documented fixes for reconnection UI flickering, chat history requests, and iOS platform identifier normalization.
- Added a migration guide for moving from `DaakiaVideoConferenceWidget.secretKey` to `DaakiaSdk.initialize(secret: ...)`.
- Linked the migration guide from the README and CHANGELOG.
- Simplified SDK initialization examples by removing optional custom domain configuration.