### PR TITLE
Chore/api version per endpoint

### DIFF
--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -33,70 +33,72 @@ import '../model/white_board_data.dart';
 
 part 'api_client.g.dart';
 
+/// [Constant.baseUrl] is the unversioned API root, so every path below must
+/// start with its own API version prefix (e.g. `v2.0/`, `v3.0/`).
 @RestApi()
 abstract class RestClient {
   factory RestClient(Dio dio, {String? baseUrl}) = _RestClient;
 
   //-------------------[PRE-JOIN]-------------------
 
-  @POST("rtc/meeting/join")
+  @POST("v2.0/rtc/meeting/join")
   Future<BaseResponse<RtcData>> getMeetingJoinDetail(
     @Header("Authorization") String token,
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("meeting/verifyHost")
+  @POST("v2.0/meeting/verifyHost")
   Future<BaseResponse<HostTokenModel>> verifyHostToken(
     @Body() Map<String, dynamic> body,
   );
 
-  @GET("saas/host/token")
+  @GET("v2.0/saas/host/token")
   Future<BaseResponse<HostTokenModel>> getHostToken(
     @Query("meeting_uid") String meetingUid,
   );
 
-  @GET("saas/meeting/features")
+  @GET("v2.0/saas/meeting/features")
   Future<BaseResponse<FeatureData>> getFeatures(
       @Query("meeting_uid") String meetingUid);
 
-  @POST("rtc/meeting/verify/commonPassword")
+  @POST("v2.0/rtc/meeting/verify/commonPassword")
   Future<BaseResponse<EventPasswordProtectedData>> verifyCommonMeetingPassword(
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("meeting/verify/password")
+  @POST("v2.0/meeting/verify/password")
   Future<BaseResponse<EventPasswordProtectedData>> verifyMeetingPassword(
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/addParticipant/toLobby")
+  @POST("v2.0/rtc/meeting/addParticipant/toLobby")
   Future<BaseResponse<RtcData>> addParticipantToLobby(
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/update/participantEmail")
+  @POST("v2.0/rtc/meeting/update/participantEmail")
   Future<BaseResponse> updateParticipantEmail(
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/update/participantJoinedStatus")
+  @POST("v2.0/rtc/meeting/update/participantJoinedStatus")
   Future<BaseResponse> updateParticipantJoinedStatus(
     @Body() Map<String, dynamic> body,
   );
 
-  @GET("rtc/meeting/participant/meetingStatus")
+  @GET("v2.0/rtc/meeting/participant/meetingStatus")
   Future<BaseResponse<MeetingStatusData>> getMeetingStatus(
     @Header("Authorization") String token,
     @Query("meeting_uid") String meetingUid,
   );
 
-  @POST("saas/sdk/verify/key")
+  @POST("v2.0/saas/sdk/verify/key")
   Future<BaseResponse<LicenceVerifyModel>> licenceVerify(
     @Body() Map<String, dynamic> body,
   );
 
-  @GET("saas/sdk/meeting/basic/detail")
+  @GET("v2.0/saas/sdk/meeting/basic/detail")
   Future<BaseResponse<MeetingDetailsModel>> getMeetingDetails(
     @Query("meeting_uid") String meetingUid,
     @Header("secret") String secret,
@@ -104,7 +106,7 @@ abstract class RestClient {
 
   //-------------------[OBSERVABILITY]-------------------
 
-  @POST("saas/sdk/observability/credentials")
+  @POST("v2.0/saas/sdk/observability/credentials")
   Future<BaseResponse<ObservabilityPayloadModel>> getObservabilityCredentials(
     @Header("secret") String secret,
     @Body() Map<String, dynamic> body,
@@ -112,34 +114,34 @@ abstract class RestClient {
 
   //-------------------[RTC]-------------------
 
-  @POST("rtc/meeting/delete")
+  @POST("v2.0/rtc/meeting/delete")
   Future<BaseResponse> endMeeting(
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/remove/participant")
+  @POST("v2.0/rtc/meeting/remove/participant")
   Future<BaseResponse> removeParticipant(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/create/cohost")
+  @POST("v2.0/rtc/meeting/create/cohost")
   Future<BaseResponse> makeCoHost(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/recording/start")
+  @POST("v2.0/rtc/meeting/recording/start")
   Future<BaseResponse<EgressData>> startRecording(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/recording/stop")
+  @POST("v2.0/rtc/meeting/recording/stop")
   Future<BaseResponse> stopRecording(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
@@ -147,32 +149,32 @@ abstract class RestClient {
   );
 
   @Deprecated("No longer needed the dispatch id")
-  @GET("rtc/recording/dispatchId")
+  @GET("v2.0/rtc/recording/dispatchId")
   Future<BaseResponse<RecordingDispatchData>> getRecordingDispatchedId(
       @Header("Authorization") String token,
       @Header("x-self-identity") String selfIdentity,
       @Query("meeting_id") String meetingUid);
 
-  @PUT("rtc/meeting/update/participantLobbyStatus")
+  @PUT("v2.0/rtc/meeting/update/participantLobbyStatus")
   Future<BaseResponse<RtcData>> acceptParticipantInLobby(
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/chat/uploadAttachment")
+  @POST("v2.0/rtc/meeting/chat/uploadAttachment")
   @MultiPart()
   Future<BaseResponse<UploadData>> uploadFile(@Part() File file,
       {@SendProgress() ProgressCallback? onSendProgress});
 
   @Deprecated("This API is no longer supported.")
-  @POST("rtc/meeting/update/transcriptionLanguage")
+  @POST("v2.0/rtc/meeting/update/transcriptionLanguage")
   Future<BaseResponse> setTranscriptionLanguage(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @PUT("rtc/meeting/update/participantLanguage")
+  @PUT("v2.0/rtc/meeting/update/participantLanguage")
   Future<BaseResponse> updateTranscriptionLanguage(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
@@ -180,77 +182,77 @@ abstract class RestClient {
   );
 
   @Deprecated("This API is no longer supported. Please use dispatchAgent instead.")
-  @POST("rtc/meeting/transcription/start")
+  @POST("v2.0/rtc/meeting/transcription/start")
   Future<BaseResponse> startTranscription(
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/dispatch/agent")
+  @POST("v2.0/rtc/meeting/dispatch/agent")
   Future<BaseResponse<AgentDispatchData>> dispatchAgent(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/text/translation")
+  @POST("v2.0/rtc/meeting/text/translation")
   Future<BaseResponse<TranslationData>> translateText(
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/transcription/stop")
+  @POST("v2.0/rtc/meeting/transcription/stop")
   Future<BaseResponse> stopTranscription(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/updateParticipant/name")
+  @POST("v2.0/rtc/meeting/updateParticipant/name")
   Future<BaseResponse> updateParticipantName(
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @POST("rtc/meeting/time/extend")
+  @POST("v2.0/rtc/meeting/time/extend")
   Future<BaseResponse> meetingTimeExtend(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @GET("rtc/meeting/whiteboard/get")
+  @GET("v2.0/rtc/meeting/whiteboard/get")
   Future<BaseListResponse<WhiteboardData>> getWhiteBoardData(
     @Header("x-self-identity") String selfIdentity,
     @Query("meeting_id") String meetingId,
   );
 
-  @GET("rtc/meeting/invitee/participantsList")
+  @GET("v2.0/rtc/meeting/invitee/participantsList")
   Future<BaseListResponse<ParticipantAttendanceData>>
       getAttendanceListForParticipant(
     @Header("x-self-identity") String selfIdentity,
     @Query("meeting_uid") String meetingId,
   );
 
-  @PUT("rtc/meeting/updateRecording/consentStatus")
+  @PUT("v2.0/rtc/meeting/updateRecording/consentStatus")
   Future<BaseResponse<ConsentStatusData>> updateRecordingConsent(
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @GET("rtc/meeting/session/detail")
+  @GET("v2.0/rtc/meeting/session/detail")
   Future<BaseResponse<SessionDetailsData>> getSessionDetails(
     @Header("x-self-identity") String selfIdentity,
     @Query("meeting_uid") String meetingId,
   );
 
-  @POST("rtc/meeting/startRecording/consent")
+  @POST("v2.0/rtc/meeting/startRecording/consent")
   Future<BaseResponse> startRecordingConsent(
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @GET("rtc/meeting/participant/consentList")
+  @GET("v2.0/rtc/meeting/participant/consentList")
   Future<BaseListResponse<RemoteParticipantConsent>> getParticipantConsentList(
     @Header("x-self-identity") String selfIdentity,
     @Query("meeting_uid") String meetingId,
@@ -259,20 +261,20 @@ abstract class RestClient {
 
   // Returns all host control states in a single call.
   // Use this instead of the individual GET endpoints below.
-  @GET("rtc/meeting/hostControls")
+  @GET("v2.0/rtc/meeting/hostControls")
   Future<BaseResponse<HostControlsData>> getHostControls(
     @Header("x-self-identity") String selfIdentity,
     @Query("meeting_uid") String meetingUid,
   );
 
   @Deprecated('Use getHostControls() instead.')
-  @GET("rtc/screenShareConsent")
+  @GET("v2.0/rtc/screenShareConsent")
   Future<BaseResponse<ScreenShareConsentModel>> getScreenShareConsent(
     @Header("x-self-identity") String selfIdentity,
     @Query("meeting_id") String meetingId,
   );
 
-  @PUT("rtc/screenShareConsent")
+  @PUT("v2.0/rtc/screenShareConsent")
   Future<BaseResponse<ScreenShareConsentModel>> updateScreenShareConsent(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
@@ -280,13 +282,13 @@ abstract class RestClient {
   );
 
   @Deprecated('Use getHostControls() instead.')
-  @GET("rtc/chatAttachmentDownloadConsent")
+  @GET("v2.0/rtc/chatAttachmentDownloadConsent")
   Future<BaseResponse<ChatAttachmentConsentModel>> getChatAttachmentConsent(
     @Header("x-self-identity") String selfIdentity,
     @Query("meeting_id") String meetingId,
   );
 
-  @PUT("rtc/chatAttachmentDownloadConsent")
+  @PUT("v2.0/rtc/chatAttachmentDownloadConsent")
   Future<BaseResponse<ChatAttachmentConsentModel>> updateChatAttachmentConsent(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
@@ -294,13 +296,13 @@ abstract class RestClient {
   );
 
   @Deprecated('Use getHostControls() instead.')
-  @GET("rtc/audioPermission")
+  @GET("v2.0/rtc/audioPermission")
   Future<BaseResponse<WebinarPermissionModel>> getAudioPermission(
     @Header("x-self-identity") String selfIdentity,
     @Query("meeting_id") String meetingId,
   );
 
-  @PUT("rtc/audioPermission")
+  @PUT("v2.0/rtc/audioPermission")
   Future<BaseResponse<WebinarPermissionModel>> updateAudioPermission(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
@@ -308,27 +310,27 @@ abstract class RestClient {
   );
 
   @Deprecated('Use getHostControls() instead.')
-  @GET("rtc/videoPermission")
+  @GET("v2.0/rtc/videoPermission")
   Future<BaseResponse<WebinarPermissionModel>> getVideoPermission(
     @Header("x-self-identity") String selfIdentity,
     @Query("meeting_id") String meetingId,
   );
 
-  @PUT("rtc/videoPermission")
+  @PUT("v2.0/rtc/videoPermission")
   Future<BaseResponse<WebinarPermissionModel>> updateVideoPermission(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @PUT("rtc/meeting/update/participantMicPermission")
+  @PUT("v2.0/rtc/meeting/update/participantMicPermission")
   Future<BaseResponse<WorkshopPermissionModel>> updateWorkshopMicPermission(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @PUT("rtc/meeting/update/participantVideoPermission")
+  @PUT("v2.0/rtc/meeting/update/participantVideoPermission")
   Future<BaseResponse<WorkshopPermissionModel>> updateWorkshopVideoPermission(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
@@ -336,27 +338,27 @@ abstract class RestClient {
   );
 
   @Deprecated('Use getHostControls() instead.')
-  @GET("rtc/meeting/get/participantDrawer")
+  @GET("v2.0/rtc/meeting/get/participantDrawer")
   Future<BaseResponse<ParticipantDrawerConsentModel>> getParticipantDrawerConsent(
     @Header("x-self-identity") String selfIdentity,
     @Query("meeting_uid") String meetingUid,
   );
 
-  @PUT("rtc/meeting/allow/participantDrawer")
+  @PUT("v2.0/rtc/meeting/allow/participantDrawer")
   Future<BaseResponse<ParticipantDrawerConsentModel>> updateParticipantDrawerConsent(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @PUT("rtc/meeting/allowAnnotation")
+  @PUT("v2.0/rtc/meeting/allowAnnotation")
   Future<BaseResponse<dynamic>> allowAnnotation(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @PUT("rtc/meeting/participant/allowAnnotation")
+  @PUT("v2.0/rtc/meeting/participant/allowAnnotation")
   Future<BaseResponse<dynamic>> allowParticipantAnnotation(
     @Header("Authorization") String token,
     @Header("x-self-identity") String selfIdentity,
@@ -365,13 +367,13 @@ abstract class RestClient {
 
   //-------------------[INVITED PARTICIPANTS]-------------------
 
-  @POST("rtc/meeting/invite/participants")
+  @POST("v2.0/rtc/meeting/invite/participants")
   Future<BaseResponse> inviteParticipants(
     @Header("x-self-identity") String selfIdentity,
     @Body() Map<String, dynamic> body,
   );
 
-  @GET("rtc/meeting/invited/participants")
+  @GET("v2.0/rtc/meeting/invited/participants")
   Future<BaseResponse<InvitedParticipantsData>> getInvitedParticipants(
     @Header("x-self-identity") String selfIdentity,
     @Query("meeting_uid") String meetingUid,

--- a/lib/api/api_client.g.dart
+++ b/lib/api/api_client.g.dart
@@ -34,7 +34,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/join',
+            'v2.0/rtc/meeting/join',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -67,7 +67,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'meeting/verifyHost',
+            'v2.0/meeting/verifyHost',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -97,7 +97,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'saas/host/token',
+            'v2.0/saas/host/token',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -127,7 +127,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'saas/meeting/features',
+            'v2.0/saas/meeting/features',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -160,7 +160,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/verify/commonPassword',
+            'v2.0/rtc/meeting/verify/commonPassword',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -194,7 +194,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'meeting/verify/password',
+            'v2.0/meeting/verify/password',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -228,7 +228,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/addParticipant/toLobby',
+            'v2.0/rtc/meeting/addParticipant/toLobby',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -263,7 +263,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/update/participantEmail',
+            'v2.0/rtc/meeting/update/participantEmail',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -296,7 +296,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/update/participantJoinedStatus',
+            'v2.0/rtc/meeting/update/participantJoinedStatus',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -330,7 +330,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/participant/meetingStatus',
+            'v2.0/rtc/meeting/participant/meetingStatus',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -363,7 +363,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'saas/sdk/verify/key',
+            'v2.0/saas/sdk/verify/key',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -397,7 +397,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'saas/sdk/meeting/basic/detail',
+            'v2.0/saas/sdk/meeting/basic/detail',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -432,7 +432,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'saas/sdk/observability/credentials',
+            'v2.0/saas/sdk/observability/credentials',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -468,7 +468,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/delete',
+            'v2.0/rtc/meeting/delete',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -507,7 +507,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/remove/participant',
+            'v2.0/rtc/meeting/remove/participant',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -546,7 +546,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/create/cohost',
+            'v2.0/rtc/meeting/create/cohost',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -585,7 +585,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/recording/start',
+            'v2.0/rtc/meeting/recording/start',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -624,7 +624,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/recording/stop',
+            'v2.0/rtc/meeting/recording/stop',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -662,7 +662,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/recording/dispatchId',
+            'v2.0/rtc/recording/dispatchId',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -697,7 +697,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/update/participantLobbyStatus',
+            'v2.0/rtc/meeting/update/participantLobbyStatus',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -745,7 +745,7 @@ class _RestClient implements RestClient {
           )
           .compose(
             _dio.options,
-            'rtc/meeting/chat/uploadAttachment',
+            'v2.0/rtc/meeting/chat/uploadAttachment',
             queryParameters: queryParameters,
             data: _data,
             onSendProgress: onSendProgress,
@@ -785,7 +785,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/update/transcriptionLanguage',
+            'v2.0/rtc/meeting/update/transcriptionLanguage',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -824,7 +824,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/update/participantLanguage',
+            'v2.0/rtc/meeting/update/participantLanguage',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -859,7 +859,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/transcription/start',
+            'v2.0/rtc/meeting/transcription/start',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -898,7 +898,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/dispatch/agent',
+            'v2.0/rtc/meeting/dispatch/agent',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -933,7 +933,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/text/translation',
+            'v2.0/rtc/meeting/text/translation',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -972,7 +972,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/transcription/stop',
+            'v2.0/rtc/meeting/transcription/stop',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1007,7 +1007,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/updateParticipant/name',
+            'v2.0/rtc/meeting/updateParticipant/name',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1046,7 +1046,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/time/extend',
+            'v2.0/rtc/meeting/time/extend',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1080,7 +1080,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/whiteboard/get',
+            'v2.0/rtc/meeting/whiteboard/get',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1113,7 +1113,7 @@ class _RestClient implements RestClient {
           Options(method: 'GET', headers: _headers, extra: _extra)
               .compose(
                 _dio.options,
-                'rtc/meeting/invitee/participantsList',
+                'v2.0/rtc/meeting/invitee/participantsList',
                 queryParameters: queryParameters,
                 data: _data,
               )
@@ -1151,7 +1151,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/updateRecording/consentStatus',
+            'v2.0/rtc/meeting/updateRecording/consentStatus',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1185,7 +1185,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/session/detail',
+            'v2.0/rtc/meeting/session/detail',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1220,7 +1220,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/startRecording/consent',
+            'v2.0/rtc/meeting/startRecording/consent',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1258,7 +1258,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/participant/consentList',
+            'v2.0/rtc/meeting/participant/consentList',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1293,7 +1293,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/hostControls',
+            'v2.0/rtc/meeting/hostControls',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1327,7 +1327,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/screenShareConsent',
+            'v2.0/rtc/screenShareConsent',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1367,7 +1367,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/screenShareConsent',
+            'v2.0/rtc/screenShareConsent',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1402,7 +1402,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/chatAttachmentDownloadConsent',
+            'v2.0/rtc/chatAttachmentDownloadConsent',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1442,7 +1442,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/chatAttachmentDownloadConsent',
+            'v2.0/rtc/chatAttachmentDownloadConsent',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1477,7 +1477,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/audioPermission',
+            'v2.0/rtc/audioPermission',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1516,7 +1516,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/audioPermission',
+            'v2.0/rtc/audioPermission',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1550,7 +1550,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/videoPermission',
+            'v2.0/rtc/videoPermission',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1589,7 +1589,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/videoPermission',
+            'v2.0/rtc/videoPermission',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1628,7 +1628,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/update/participantMicPermission',
+            'v2.0/rtc/meeting/update/participantMicPermission',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1668,7 +1668,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/update/participantVideoPermission',
+            'v2.0/rtc/meeting/update/participantVideoPermission',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1702,7 +1702,7 @@ class _RestClient implements RestClient {
           Options(method: 'GET', headers: _headers, extra: _extra)
               .compose(
                 _dio.options,
-                'rtc/meeting/get/participantDrawer',
+                'v2.0/rtc/meeting/get/participantDrawer',
                 queryParameters: queryParameters,
                 data: _data,
               )
@@ -1747,7 +1747,7 @@ class _RestClient implements RestClient {
           Options(method: 'PUT', headers: _headers, extra: _extra)
               .compose(
                 _dio.options,
-                'rtc/meeting/allow/participantDrawer',
+                'v2.0/rtc/meeting/allow/participantDrawer',
                 queryParameters: queryParameters,
                 data: _data,
               )
@@ -1790,7 +1790,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/allowAnnotation',
+            'v2.0/rtc/meeting/allowAnnotation',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1829,7 +1829,7 @@ class _RestClient implements RestClient {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/participant/allowAnnotation',
+            'v2.0/rtc/meeting/participant/allowAnnotation',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1864,7 +1864,7 @@ class _RestClient implements RestClient {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/invite/participants',
+            'v2.0/rtc/meeting/invite/participants',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -1898,7 +1898,7 @@ class _RestClient implements RestClient {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            'rtc/meeting/invited/participants',
+            'v2.0/rtc/meeting/invited/participants',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/model/meeting_details_model.dart
+++ b/lib/model/meeting_details_model.dart
@@ -64,7 +64,7 @@ class MeetingDetailsModel {
     startDate = json['start_date'];
     endDate = json['end_date'];
     duration = json['duration'];
-    isStartNow = json['is_start_now'];
+    isStartNow = _parseNullableInt(json['is_start_now']);
     topic = json['topic'];
     timeZone = json['time_zone'];
     timezoneIdentifier = json['timezone_identifier'];
@@ -75,14 +75,16 @@ class MeetingDetailsModel {
     roomUid = json['room_uid'];
     conferenceStatusId = json['conference_status_id'];
     totalMembersCount = json['total_members_count'];
-    isPassword = json['is_password'];
+    isPassword = json['is_password']?.toString();
     conferenceStatus = json['conference_status'] != null
         ? ConferenceStatus.fromJson(json['conference_status'])
         : null;
     isLobbyMode = json['is_lobby_mode'];
     isStandardPassword = json['is_standard_password'];
     isCommonPassword = json['is_common_password'];
-    currentSessionUid = json['current_session_uid'].toString();
+    // `?.` matters here: a plain `.toString()` turns a null session into the
+    // literal string "null".
+    currentSessionUid = json['current_session_uid']?.toString();
     transcriptionDetail = json['transcription_detail'] != null
         ? TranscriptionDetail.fromJson(json['transcription_detail'])
         : null;
@@ -130,6 +132,15 @@ class MeetingDetailsModel {
     data['host_pin_verification_required'] = hostPinVerificationRequired;
     return data;
   }
+}
+
+/// The backend returns some flags as `1`/`0` on one endpoint and `true`/`false`
+/// on another (e.g. `is_start_now`), so normalise instead of assigning raw JSON.
+int? _parseNullableInt(dynamic value) {
+  if (value == null) return null;
+  if (value is int) return value;
+  if (value is bool) return value ? 1 : 0;
+  return int.tryParse(value.toString());
 }
 
 class ConferenceStatus {

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -6,7 +6,7 @@ class Constant {
 
   static final String platform = getPlatform();
 
-  static String baseUrl = "https://api.daakia.co.in/v2.0/";
+  static String baseUrl = "https://api.daakia.co.in/";
   static String whiteboardDomain = "https://www.daakia.co.in/";
 
   static const String startRecordingUrl = "https://cdn.vc.daakia.co.in/sounds/recording_start.mp3";


### PR DESCRIPTION
## Summary

This PR refactors API versioning to support version-specific endpoints and improves resilience against meeting detail payload type changes.

## Changes

- Changed `Constant.baseUrl` to use the unversioned API root.
- Moved API version prefixes from the base URL into individual `RestClient` endpoints.
- Enabled endpoints from different API versions to be called independently.
- **Breaking Change:** `DaakiaSdk.initialize(baseUrl:)` must now receive an unversioned root URL.
- Updated meeting detail parsing to support `is_start_now` changing from `1` to `true`.
- Updated `is_password` parsing to support both string and boolean values.
- Fixed `current_session_uid` handling to avoid converting a null value into the literal string `"null"`.