### PR TITLE
Feat/guest mode join

### DIFF
--- a/lib/model/meeting_details_model.dart
+++ b/lib/model/meeting_details_model.dart
@@ -176,8 +176,9 @@ class MeetingConfig {
   int? autoMeetingEnd;
   String? autoMeetingEndSchedule;
   String? autoMeetingEndScheduleTimezoneFormated;
+  int? isGuestMode;
 
-  MeetingConfig({autoStartRecording, recordingForceStopped, autoMeetingEnd, autoMeetingEndSchedule, autoMeetingEndScheduleTimezoneFormated});
+  MeetingConfig({autoStartRecording, recordingForceStopped, autoMeetingEnd, autoMeetingEndSchedule, autoMeetingEndScheduleTimezoneFormated, this.isGuestMode});
 
   MeetingConfig.fromJson(Map<String, dynamic> json) {
     autoStartRecording = json['auto_start_recording'];
@@ -185,6 +186,7 @@ class MeetingConfig {
     autoMeetingEnd = json['auto_meeting_end'];
     autoMeetingEndSchedule = json['auto_meeting_end_schedule'];
     autoMeetingEndScheduleTimezoneFormated = json['auto_meeting_end_schedule_timezone_formated'];
+    isGuestMode = _parseFlag(json['is_guest_mode']);
   }
 
   Map<String, dynamic> toJson() {
@@ -194,6 +196,15 @@ class MeetingConfig {
     data['auto_meeting_end'] = autoMeetingEnd;
     data['auto_meeting_end_schedule'] = autoMeetingEndSchedule;
     data['auto_meeting_end_schedule_timezone_formated'] = autoMeetingEndScheduleTimezoneFormated;
+    data['is_guest_mode'] = isGuestMode;
     return data;
+  }
+
+  // Backend usually sends is_guest_mode as an int flag (0/1) but may send a bool.
+  static int? _parseFlag(dynamic value) {
+    if (value == null) return null;
+    if (value is bool) return value ? 1 : 0;
+    if (value is int) return value;
+    return int.tryParse(value.toString());
   }
 }

--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -57,6 +57,8 @@ class _PreJoinState extends State<PreJoinScreen> {
   var name = "";
   var password = "";
   String? _participantEmail;
+  bool _joinAsGuest = false;
+  String _guestEmail = "";
 
   var _obscurePassword = true;
 
@@ -120,6 +122,13 @@ class _PreJoinState extends State<PreJoinScreen> {
       widget.configuration?.vcConfig?.isCoHost == true;
   bool get _shouldBypassParticipantChecks =>
       _isCoHostVerified || _isConfiguredCoHost;
+
+  // Guest join is only offered when the meeting is password-protected and the
+  // backend has enabled it for this meeting via meeting_config.is_guest_mode.
+  bool get _isGuestModeAvailable =>
+      widget.basicMeetingDetails?.meetingConfig?.isGuestMode == 1 &&
+      (widget.basicMeetingDetails?.isStandardPassword == true ||
+          widget.basicMeetingDetails?.isCommonPassword == true);
 
   Future<void> _initializeMediaState() async {
     try {
@@ -384,6 +393,13 @@ class _PreJoinState extends State<PreJoinScreen> {
     final Map<String, dynamic> customMetadata =
         Map<String, dynamic>.from(widget.configuration?.metadata ?? {});
     customMetadata["client_platform"] = Utils.getClientPlatform();
+    if (_joinAsGuest && _isGuestModeAvailable) {
+      body["email"] = _participantEmail;
+      body["is_guest"] = true;
+      customMetadata["identifier"] = _participantEmail;
+      customMetadata["participant_email"] = _participantEmail;
+      customMetadata["participant_type"] = "guest";
+    }
     body["custom_metadata"] = customMetadata;
     final cacheData = StorageHelper();
     var tokenFromCache = false;
@@ -480,6 +496,7 @@ class _PreJoinState extends State<PreJoinScreen> {
 
   void _handleRejection(Function stopLoading) {
     isRejected = true;
+    lobbyRequestId = "";
     if (_shouldSkipPreJoin) {
       _skipJoinErrorMessage = alertMessage;
     }
@@ -571,6 +588,12 @@ class _PreJoinState extends State<PreJoinScreen> {
       "meeting_uid": widget.meetingId,
       "display_name": name.trim(),
     };
+    if (_participantEmail != null && _participantEmail!.isNotEmpty) {
+      body["email"] = _participantEmail;
+    }
+    if (_joinAsGuest && _isGuestModeAvailable) {
+      body["is_guest"] = true;
+    }
 
     networkRequestHandler(
         apiCall: () => apiClient.addParticipantToLobby(body),
@@ -974,6 +997,7 @@ class _PreJoinState extends State<PreJoinScreen> {
                   Visibility(
                     visible: !widget.isHost &&
                         !_shouldBypassParticipantChecks &&
+                        !_joinAsGuest &&
                         (widget.basicMeetingDetails?.isCommonPassword == true ||
                             widget.basicMeetingDetails?.isStandardPassword ==
                                 true),
@@ -1010,6 +1034,32 @@ class _PreJoinState extends State<PreJoinScreen> {
                       ),
                     ),
                   ),
+                  Visibility(
+                    visible: !widget.isHost &&
+                        !_shouldBypassParticipantChecks &&
+                        _joinAsGuest &&
+                        _isGuestModeAvailable,
+                    child: Container(
+                      margin: const EdgeInsets.symmetric(
+                          horizontal: 20, vertical: 10),
+                      child: TextFormField(
+                        decoration: const InputDecoration(
+                          labelText: 'Email*',
+                          border: OutlineInputBorder(),
+                        ),
+                        style: const TextStyle(
+                          color: Colors.black,
+                        ),
+                        enabled: true,
+                        keyboardType: TextInputType.emailAddress,
+                        onChanged: (String? value) {
+                          setState(() {
+                            _guestEmail = (value ?? "").trim();
+                          });
+                        },
+                      ),
+                    ),
+                  ),
                   const SizedBox(height: 20),
                   LoadingBtn(
                     height: 50,
@@ -1040,17 +1090,26 @@ class _PreJoinState extends State<PreJoinScreen> {
                             !_shouldBypassParticipantChecks &&
                             !await shouldAddAttendanceId()) {
                           var event = widget.basicMeetingDetails;
-                          if (event?.isStandardPassword == true) {
-                            if (!checkValidity()) {
-                              return;
-                            }
-                          }
-                          if (event?.isCommonPassword == true) {
-                            if (password.isEmpty) {
+                          if (_joinAsGuest && _isGuestModeAvailable) {
+                            if (!Utils.isValidEmail(_guestEmail)) {
                               if (!context.mounted) return;
                               Utils.showSnackBar(context,
-                                  message: "Please enter your password");
+                                  message: "Please enter a valid email");
                               return;
+                            }
+                          } else {
+                            if (event?.isStandardPassword == true) {
+                              if (!checkValidity()) {
+                                return;
+                              }
+                            }
+                            if (event?.isCommonPassword == true) {
+                              if (password.isEmpty) {
+                                if (!context.mounted) return;
+                                Utils.showSnackBar(context,
+                                    message: "Please enter your password");
+                                return;
+                              }
                             }
                           }
                         }
@@ -1088,6 +1147,31 @@ class _PreJoinState extends State<PreJoinScreen> {
                       }
                     },
                   ),
+                  Visibility(
+                    visible: !widget.isHost &&
+                        !_shouldBypassParticipantChecks &&
+                        _isGuestModeAvailable,
+                    child: Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: TextButton.icon(
+                        onPressed: _toggleGuestMode,
+                        icon: Icon(
+                          _joinAsGuest ? Icons.lock_outline : Icons.person_outline,
+                          size: 18,
+                          color: themeColor,
+                        ),
+                        label: Text(
+                          _joinAsGuest
+                              ? "Have a password? Join with password"
+                              : "Join as Guest instead",
+                          style: const TextStyle(
+                            color: themeColor,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -1095,6 +1179,22 @@ class _PreJoinState extends State<PreJoinScreen> {
         ],
       ),
     );
+  }
+
+  void _toggleGuestMode() {
+    // Abort any in-flight lobby polling from a previous attempt so switching
+    // modes mid-flight doesn't leave a stale lobby_request_id around.
+    _participantTimer?.cancel();
+    setState(() {
+      _joinAsGuest = !_joinAsGuest;
+      lobbyRequestId = "";
+      if (_joinAsGuest) {
+        password = "";
+      } else {
+        _guestEmail = "";
+        _participantEmail = null;
+      }
+    });
   }
 
   Widget _buildSkipPreJoinLoader() {
@@ -1396,6 +1496,23 @@ class _PreJoinState extends State<PreJoinScreen> {
     }
     if (widget.isHost) {
       getFeaturesAndJoinMeeting(stopLoading);
+    } else if (_joinAsGuest && _isGuestModeAvailable) {
+      if (!Utils.isValidEmail(_guestEmail)) {
+        if (mounted) {
+          Utils.showSnackBar(context, message: "Please enter a valid email");
+        }
+        stopLoading();
+        return;
+      }
+      if (isNeedToCancelApiCall) {
+        stopLoading();
+        return;
+      }
+      _participantEmail = _guestEmail;
+      // Same as the standard lobby flow: register the guest via addToLobby
+      // to get a server-issued lobby_request_id, then poll join with it
+      // until the host accepts/rejects.
+      addParticipantToLobby(stopLoading);
     } else if (event?.isStandardPassword == true) {
       if (checkValidity()) {
         verifyPasswordProtectedMeeting(stopLoading);

--- a/lib/presentation/screens/prejoin_screen.dart
+++ b/lib/presentation/screens/prejoin_screen.dart
@@ -796,7 +796,11 @@ class _PreJoinState extends State<PreJoinScreen> {
           livekitToken: livekitToken,
           features: features,
           meetingBasicDetails: widget.basicMeetingDetails,
-          participantEmail: _participantEmail);
+          // Guests must never trigger notifyParticipantJoinedStatus: that call
+          // marks a pre-registered participant email as joined, so forwarding
+          // a guest-entered email would let a guest impersonate/mark a real
+          // invited participant as joined just by typing their address.
+          participantEmail: _joinAsGuest ? null : _participantEmail);
       if (mounted) {
         final navigator = Navigator.of(this.context);
         await navigator.push<void>(

--- a/lib/presentation/widgets/participant_tile.dart
+++ b/lib/presentation/widgets/participant_tile.dart
@@ -92,13 +92,31 @@ class ParticipantTile extends StatelessWidget {
                       children: [
                         TextSpan(
                           text:
-                              "${Utils.calculateMinutesSince(participant?.joinedAt)} mins ${Utils.getParticipantType(participant?.metadata)}",
+                              "${Utils.calculateMinutesSince(participant?.joinedAt)} mins",
                           style: const TextStyle(
                             color: Color(0xFFC4C1B8),
                             // Equivalent to the text color used
                             fontSize: 12,
                           ),
                         ),
+                        if (Utils.isHost(participant?.metadata))
+                          const TextSpan(
+                            text: " (Host)",
+                            style: TextStyle(
+                              color: Colors.amberAccent,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        if (Utils.isCoHost(participant?.metadata))
+                          const TextSpan(
+                            text: " (Co-Host)",
+                            style: TextStyle(
+                              color: Colors.lightBlueAccent,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
                         if (Utils.isGuest(participant?.metadata))
                           const TextSpan(
                             text: " (Guest)",

--- a/lib/presentation/widgets/participant_tile.dart
+++ b/lib/presentation/widgets/participant_tile.dart
@@ -46,26 +46,69 @@ class ParticipantTile extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text(
-                  (isForLobby
-                          ? lobbyRequest?.displayName
-                          : participant?.name) ??
-                      "Unknown",
-                  // Replace with the participant's name
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 18,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+                Row(
+                  children: [
+                    Flexible(
+                      child: Text(
+                        (isForLobby
+                                ? lobbyRequest?.displayName
+                                : participant?.name) ??
+                            "Unknown",
+                        // Replace with the participant's name
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 18,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    if (!isForLobby &&
+                        participant?.identity ==
+                            viewModel.room.localParticipant?.identity) ...[
+                      const SizedBox(width: 6),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: Colors.white24,
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        child: const Text(
+                          'You',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 11,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
                 ),
                 if (!isForLobby)
-                  Text(
-                    "${Utils.calculateMinutesSince(participant?.joinedAt)} mins ${Utils.getParticipantType(participant?.metadata)}", // Replace with details text
-                    style: const TextStyle(
-                      color: Color(0xFFC4C1B8),
-                      // Equivalent to the text color used
-                      fontSize: 12,
+                  Text.rich(
+                    TextSpan(
+                      children: [
+                        TextSpan(
+                          text:
+                              "${Utils.calculateMinutesSince(participant?.joinedAt)} mins ${Utils.getParticipantType(participant?.metadata)}",
+                          style: const TextStyle(
+                            color: Color(0xFFC4C1B8),
+                            // Equivalent to the text color used
+                            fontSize: 12,
+                          ),
+                        ),
+                        if (Utils.isGuest(participant?.metadata))
+                          const TextSpan(
+                            text: " (Guest)",
+                            style: TextStyle(
+                              color: Colors.greenAccent,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                      ],
                     ),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,

--- a/lib/rtc/widgets/participant_quick_actions.dart
+++ b/lib/rtc/widgets/participant_quick_actions.dart
@@ -190,13 +190,13 @@ class _ParticipantQuickActionsSheetState
                           Text(
                             roleLabel,
                             style: TextStyle(
-                              color: isTargetGuest
-                                  ? Colors.greenAccent
-                                  : Colors.grey[400],
+                              color: isTargetHost
+                                  ? Colors.amberAccent
+                                  : (isTargetCoHost
+                                      ? Colors.lightBlueAccent
+                                      : Colors.greenAccent),
                               fontSize: 12,
-                              fontWeight: isTargetGuest
-                                  ? FontWeight.w600
-                                  : FontWeight.normal,
+                              fontWeight: FontWeight.w600,
                             ),
                           ),
                       ],

--- a/lib/rtc/widgets/participant_quick_actions.dart
+++ b/lib/rtc/widgets/participant_quick_actions.dart
@@ -103,11 +103,10 @@ class _ParticipantQuickActionsSheetState
         ? 'Host'
         : (isTargetCoHost ? 'Co-Host' : (isTargetGuest ? 'Guest' : ''));
 
-    return Container(
-      decoration: const BoxDecoration(
-        color: Color(0xFF1E1E1E),
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
+    return Material(
+      color: const Color(0xFF1E1E1E),
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+      clipBehavior: Clip.antiAlias,
       child: SafeArea(
         child: Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/rtc/widgets/participant_quick_actions.dart
+++ b/lib/rtc/widgets/participant_quick_actions.dart
@@ -62,6 +62,7 @@ class _ParticipantQuickActionsSheetState
 
     final bool isTargetHost = Utils.isHost(participant.metadata);
     final bool isTargetCoHost = Utils.isCoHost(participant.metadata);
+    final bool isTargetGuest = Utils.isGuest(participant.metadata);
     final bool isSelf =
         participant.identity == viewModel.room.localParticipant?.identity;
 
@@ -98,8 +99,9 @@ class _ParticipantQuickActionsSheetState
     final String displayName = participant.name.isNotEmpty
         ? participant.name
         : participant.identity;
-    final String roleLabel =
-        isTargetHost ? 'Host' : (isTargetCoHost ? 'Co-Host' : '');
+    final String roleLabel = isTargetHost
+        ? 'Host'
+        : (isTargetCoHost ? 'Co-Host' : (isTargetGuest ? 'Guest' : ''));
 
     return Container(
       decoration: const BoxDecoration(
@@ -188,8 +190,13 @@ class _ParticipantQuickActionsSheetState
                           Text(
                             roleLabel,
                             style: TextStyle(
-                              color: Colors.grey[400],
+                              color: isTargetGuest
+                                  ? Colors.greenAccent
+                                  : Colors.grey[400],
                               fontSize: 12,
+                              fontWeight: isTargetGuest
+                                  ? FontWeight.w600
+                                  : FontWeight.normal,
                             ),
                           ),
                       ],

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -158,19 +158,6 @@ class Utils {
     }
   }
 
-  static String getParticipantType(String? metadata) {
-    String role = getMetadataRole(metadata);
-
-    switch (role) {
-      case 'moderator':
-        return ' (Host)';
-      case 'cohost':
-        return ' (Co-Host)';
-      default:
-        return '';
-    }
-  }
-
   static bool isHost(String? metadata) {
     String role = getMetadataRole(metadata);
     return role == 'moderator';

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -181,6 +181,16 @@ class Utils {
     return role == 'cohost';
   }
 
+  static bool isGuest(String? metadata) {
+    if (metadata == null) return false;
+    try {
+      final jsonObject = jsonDecode(metadata);
+      return jsonObject['is_guest'] == true;
+    } catch (e) {
+      return false;
+    }
+  }
+
   static Future<bool> isIosSimulator() async {
     var isRealDevice = await SafeDevice.isRealDevice;
     return isRealDevice;


### PR DESCRIPTION
## Summary

This PR adds guest join support for password-protected meetings and improves participant identification and quick action UI handling.

## Changes

- Added `isGuestMode` to `MeetingConfig` with flexible parsing for `bool`, `int`, and `String` backend values.
- Implemented guest join flow for password-protected meetings using email instead of a password.
- Added guest mode detection and a toggle between password and guest join options in `PreJoinScreen`.
- Added guest email input and validation.
- Updated `joinMeeting` and `addToLobby` to support guest participant details.
- Added cleanup and timer handling when switching between guest and password join modes.
- Prevented guest-entered emails from triggering participant joined-status notifications to avoid identity impersonation.
- Added guest user identification support.
- Added role-based participant color identification.
- Refactored `ParticipantQuickActions` to use `Material` with proper clipping and surface styling.