### PR TITLE
Fix/sentry log routing

### DIFF
--- a/lib/api/injection.dart
+++ b/lib/api/injection.dart
@@ -37,6 +37,11 @@ Dio setDio() {
         handler.next(response);
       },
       onError: (DioException e, handler) {
+        // Every failure is logged to Datadog. Only `badResponse` — the backend
+        // actually answered with a non-2xx — reaches Sentry; timeouts, cancels
+        // and connection drops are the user's network, not a defect, and would
+        // bury real issues.
+        final isServerFault = e.type == DioExceptionType.badResponse;
         DaakiaVcLogger.logError(
           Utils.extractMessage("Error", e.requestOptions.data, e.requestOptions.path),
           error: e,
@@ -47,7 +52,9 @@ Dio setDio() {
             'payload': e.requestOptions.data,
             'response': e.response?.data,
             'statusCode': e.response?.statusCode,
+            'dioErrorType': e.type.name,
           },
+          reportToSentry: isServerFault,
         );
         handler.next(e);
       },

--- a/lib/service/daakia_vc_logger.dart
+++ b/lib/service/daakia_vc_logger.dart
@@ -8,6 +8,21 @@ import 'daakia_vc_sentry_service.dart';
 ///
 /// Both services are independent — initialize either or both; an uninitialized
 /// service is silently skipped without affecting the other.
+///
+/// ## Routing policy
+///
+/// Datadog is the firehose: every log level reaches it, including routine
+/// lifecycle telemetry (API responses, disconnects, reconnect attempts).
+///
+/// Sentry is for actionable faults only — crashes, uncaught exceptions and
+/// response-parsing failures. Anything expected during a healthy meeting must
+/// not reach it, or real issues drown in noise. Concretely:
+///
+/// - [logDebug] / [logInfo] never reach Sentry.
+/// - [logWarning] / [logError] reach Sentry by default; pass
+///   `reportToSentry: false` for events that are logged at those levels for
+///   Datadog dashboards but are not defects (e.g. reconnect attempts).
+/// - [captureException] is Sentry-only.
 class DaakiaVcLogger {
   DaakiaVcLogger._();
 
@@ -45,17 +60,18 @@ class DaakiaVcLogger {
     DaakiaVcDatadogService.logDebug(message, attributes: attributes);
   }
 
+  /// Datadog only — informational events are never Sentry issues.
   static void logInfo(String message, {Map<String, Object?>? attributes}) {
     DaakiaVcDatadogService.logInfo(message, attributes: attributes);
-    DaakiaVcSentryService.captureMessage(
-      message,
-      level: SentryLevel.info,
-      context: attributes,
-    );
   }
 
-  static void logWarning(String message, {Map<String, Object?>? attributes}) {
+  static void logWarning(
+    String message, {
+    Map<String, Object?>? attributes,
+    bool reportToSentry = true,
+  }) {
     DaakiaVcDatadogService.logWarning(message, attributes: attributes);
+    if (!reportToSentry) return;
     DaakiaVcSentryService.captureMessage(
       message,
       level: SentryLevel.warning,
@@ -65,13 +81,18 @@ class DaakiaVcLogger {
 
   /// Logs an error message to Datadog; Sentry receives it as an exception
   /// (with stack trace) if [error] is provided, or as an error message if not.
+  ///
+  /// Set [reportToSentry] to false for events that belong at error level in
+  /// Datadog but are not defects — they would otherwise bury real issues.
   static void logError(
     String message, {
     dynamic error,
     StackTrace? stackTrace,
     Map<String, Object?>? attributes,
+    bool reportToSentry = true,
   }) {
     DaakiaVcDatadogService.logError(message, null, null, attributes);
+    if (!reportToSentry) return;
     if (error != null) {
       DaakiaVcSentryService.captureException(
         error,

--- a/lib/utils/datadog_reconnect_logger.dart
+++ b/lib/utils/datadog_reconnect_logger.dart
@@ -49,9 +49,12 @@ class DatadogReconnectLogger {
       }
     };
 
+    // Datadog only: a reconnect attempt is transient network churn, not a
+    // defect, so it must not open a Sentry issue.
     DaakiaVcLogger.logError(
       'Reconnecting to the room!!!',
       attributes: attributes,
+      reportToSentry: false,
     );
   }
 }


### PR DESCRIPTION
## Summary

This PR refines observability routing to keep expected network and informational events out of Sentry while preserving Datadog coverage.

## Changes

- Changed `logInfo` to report only to Datadog instead of Sentry.
- Added a `reportToSentry` flag to `logWarning` and `logError` for selective Sentry reporting.
- Updated observability documentation to clarify Datadog vs. Sentry routing behavior.
- Prevented transient `RoomAttemptReconnectEvent` events from being reported to Sentry while keeping them available in Datadog.
- Restricted Dio error reporting to `badResponse` errors for Sentry.
- Kept all Dio failures logged to Datadog and added `dioErrorType` for better error categorization.
- Reduced Sentry noise from successful requests, reconnect attempts, timeouts, cancellations, and connection failures.